### PR TITLE
fixing getFileFromZip filePath

### DIFF
--- a/apiUtils/helpers/ZipHelper.ts
+++ b/apiUtils/helpers/ZipHelper.ts
@@ -27,7 +27,12 @@ export class ZipHelper {
 
   static async getFileFromZip(zip: AdmZip, filePath: string): Promise<Buffer> {
     const entries = zip.getEntries();
-    const entry = entries.find((entry) => entry.entryName === filePath);
+    const entry = entries.find((entry) => {
+      // issue then the filepath comming like : assets\enter
+      // but the enteryName will return assets/enter
+      filePath = filePath.replaceAll('\\', '/')
+      return entry.entryName === filePath
+    });
     if (!entry) throw new Error(`File not found in zip: ${filePath}`);
     return entry.getData();
   }


### PR DESCRIPTION
<!--
## Fixing method getFileFromZip  
// Issue: The file path comes as assets\enter // but entryName returns assets/enter
<!-- Please include a summary of the change and which issue is fixed. -->

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] New feature (non-breaking change which adds functionality)
- [ x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## For Bug Fixes
<!-- Please complete the following sections if this is a bug fix -->

### Describe the bug
<!-- A clear description of what the bug is -->

### Steps to reproduce
1. 
2. 
3. 

### Expected behavior
<!-- What you expected to happen -->

### Actual behavior
<!-- What actually happened -->

## Testing
<!-- Please describe the tests you've added or modified -->

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective
-->
