### PR TITLE
feat: New S3 Provider with IAM Roles for S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,8 +253,9 @@ Currently, we support:
 - Local filesystem storage
 - Google Cloud Storage (gcs)
 - AWS S3 Compatible Storage (s3)
+- AWS S3 with IAM Credentials (s3-iam)
 
-More providers (S3, Azure, etc.) are welcome to be implemented by the community. The `StorageInterface` is quite simple and you can implement it for any blob storage service.
+More providers (Azure, etc.) are welcome to be implemented by the community. The `StorageInterface` is quite simple and you can implement it for any blob storage service.
 </details>
 
 <details>

--- a/__tests__/s3IamStorage.test.ts
+++ b/__tests__/s3IamStorage.test.ts
@@ -1,0 +1,189 @@
+import { S3Client } from '@aws-sdk/client-s3';
+import { S3IamStorage } from '../apiUtils/storage/S3IamStorage';
+
+jest.mock('@aws-sdk/client-s3', () => {
+  const actual = jest.requireActual('@aws-sdk/client-s3');
+  return {
+    ...actual,
+    S3Client: jest.fn().mockImplementation(() => ({
+      send: jest.fn(),
+    })),
+  };
+});
+
+const MockedS3Client = S3Client as jest.MockedClass<typeof S3Client>;
+
+describe('S3IamStorage', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...originalEnv };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('should throw if S3_BUCKET_NAME is not set', () => {
+    delete process.env.S3_BUCKET_NAME;
+    delete process.env.S3_ACCESS_KEY_ID;
+    delete process.env.S3_SECRET_ACCESS_KEY;
+
+    expect(() => new S3IamStorage()).toThrow('S3 bucket name not configured');
+  });
+
+  it('should create client with explicit credentials when access keys are provided', () => {
+    process.env.S3_BUCKET_NAME = 'my-bucket';
+    process.env.S3_ACCESS_KEY_ID = 'test-key';
+    process.env.S3_SECRET_ACCESS_KEY = 'test-secret';
+    process.env.S3_REGION = 'us-east-1';
+
+    new S3IamStorage();
+
+    expect(MockedS3Client).toHaveBeenCalledWith(
+      expect.objectContaining({
+        region: 'us-east-1',
+        credentials: {
+          accessKeyId: 'test-key',
+          secretAccessKey: 'test-secret',
+        },
+      })
+    );
+  });
+
+  it('should create client without credentials when access keys are absent', () => {
+    process.env.S3_BUCKET_NAME = 'my-bucket';
+    delete process.env.S3_ACCESS_KEY_ID;
+    delete process.env.S3_SECRET_ACCESS_KEY;
+
+    new S3IamStorage();
+
+    const callArgs = MockedS3Client.mock.calls[0][0];
+    expect(callArgs).not.toHaveProperty('credentials');
+  });
+
+  it('should default region to auto when S3_REGION is not set', () => {
+    process.env.S3_BUCKET_NAME = 'my-bucket';
+    delete process.env.S3_REGION;
+    delete process.env.S3_ACCESS_KEY_ID;
+    delete process.env.S3_SECRET_ACCESS_KEY;
+
+    new S3IamStorage();
+
+    expect(MockedS3Client).toHaveBeenCalledWith(
+      expect.objectContaining({ region: 'auto' })
+    );
+  });
+
+  it('should pass S3_ENDPOINT when set', () => {
+    process.env.S3_BUCKET_NAME = 'my-bucket';
+    process.env.S3_ENDPOINT = 'https://custom-endpoint.example.com';
+    delete process.env.S3_ACCESS_KEY_ID;
+    delete process.env.S3_SECRET_ACCESS_KEY;
+
+    new S3IamStorage();
+
+    expect(MockedS3Client).toHaveBeenCalledWith(
+      expect.objectContaining({
+        endpoint: 'https://custom-endpoint.example.com',
+      })
+    );
+  });
+
+  it('should not include credentials when only one key is provided', () => {
+    process.env.S3_BUCKET_NAME = 'my-bucket';
+    process.env.S3_ACCESS_KEY_ID = 'test-key';
+    delete process.env.S3_SECRET_ACCESS_KEY;
+
+    new S3IamStorage();
+
+    const callArgs = MockedS3Client.mock.calls[0][0];
+    expect(callArgs).not.toHaveProperty('credentials');
+  });
+
+  describe('methods', () => {
+    let storage: S3IamStorage;
+    let mockSend: jest.Mock;
+
+    beforeEach(() => {
+      process.env.S3_BUCKET_NAME = 'my-bucket';
+      delete process.env.S3_ACCESS_KEY_ID;
+      delete process.env.S3_SECRET_ACCESS_KEY;
+
+      storage = new S3IamStorage();
+      mockSend = (MockedS3Client.mock.results[0].value as any).send;
+    });
+
+    it('uploadFile should send PutObjectCommand and return path', async () => {
+      mockSend.mockResolvedValueOnce({});
+
+      const result = await storage.uploadFile('path/to/file.bin', Buffer.from('data'));
+
+      expect(mockSend).toHaveBeenCalledTimes(1);
+      const command = mockSend.mock.calls[0][0];
+      expect(command.constructor.name).toBe('PutObjectCommand');
+      expect(result).toBe('path/to/file.bin');
+    });
+
+    it('downloadFile should return buffer from response body', async () => {
+      const bodyBytes = new Uint8Array([1, 2, 3]);
+      mockSend.mockResolvedValueOnce({
+        Body: { transformToByteArray: () => Promise.resolve(bodyBytes) },
+      });
+
+      const result = await storage.downloadFile('path/to/file.bin');
+
+      expect(Buffer.isBuffer(result)).toBe(true);
+      expect(result).toEqual(Buffer.from(bodyBytes));
+    });
+
+    it('downloadFile should throw when body is empty', async () => {
+      mockSend.mockResolvedValueOnce({ Body: { transformToByteArray: () => Promise.resolve(undefined) } });
+
+      await expect(storage.downloadFile('path/to/file.bin')).rejects.toThrow(
+        'No body found in response'
+      );
+    });
+
+    it('listFiles should return mapped file entries', async () => {
+      const now = new Date('2025-01-01T00:00:00Z');
+      mockSend.mockResolvedValueOnce({
+        Contents: [
+          { Key: 'dir/file.json', LastModified: now, Size: 42 },
+        ],
+      });
+
+      const result = await storage.listFiles('dir');
+
+      expect(result).toEqual([
+        {
+          name: 'file.json',
+          updated_at: now.toISOString(),
+          created_at: now.toISOString(),
+          metadata: { size: 42, mimetype: 'application/json' },
+        },
+      ]);
+    });
+
+    it('listDirectories should return stripped prefixes', async () => {
+      mockSend.mockResolvedValueOnce({
+        CommonPrefixes: [{ Prefix: 'root/subdir/' }],
+      });
+
+      const result = await storage.listDirectories('root/');
+
+      expect(result).toEqual(['subdir']);
+    });
+
+    it('copyFile should send CopyObjectCommand', async () => {
+      mockSend.mockResolvedValueOnce({});
+
+      await storage.copyFile('source/path', 'dest/path');
+
+      expect(mockSend).toHaveBeenCalledTimes(1);
+      const command = mockSend.mock.calls[0][0];
+      expect(command.constructor.name).toBe('CopyObjectCommand');
+    });
+  });
+});

--- a/apiUtils/storage/S3IamStorage.ts
+++ b/apiUtils/storage/S3IamStorage.ts
@@ -21,6 +21,8 @@ export class S3IamStorage implements StorageInterface {
       region: process.env.S3_REGION ?? 'auto',
       endpoint: process.env.S3_ENDPOINT,
     };
+    // If the credentials are provided, use them
+    // This way of accessing AWS resources is not recommended for production use
     if (process.env.S3_ACCESS_KEY_ID && process.env.S3_SECRET_ACCESS_KEY) {
       config.credentials = {
         accessKeyId: process.env.S3_ACCESS_KEY_ID,

--- a/apiUtils/storage/S3IamStorage.ts
+++ b/apiUtils/storage/S3IamStorage.ts
@@ -5,6 +5,7 @@ import {
   ListObjectsV2Command,
   PutObjectCommand,
   CopyObjectCommand,
+  S3ClientConfig,
 } from '@aws-sdk/client-s3';
 import { StorageInterface } from './StorageInterface';
 
@@ -16,20 +17,17 @@ export class S3IamStorage implements StorageInterface {
     if (!process.env.S3_BUCKET_NAME) {
       throw new Error('S3 bucket name not configured');
     }
-
-    const hasExplicitCredentials =
-      process.env.S3_ACCESS_KEY_ID && process.env.S3_SECRET_ACCESS_KEY;
-
-    this.client = new S3Client({
+    const config: S3ClientConfig = {
       region: process.env.S3_REGION ?? 'auto',
       endpoint: process.env.S3_ENDPOINT,
-      ...(hasExplicitCredentials && {
-        credentials: {
-          accessKeyId: process.env.S3_ACCESS_KEY_ID!,
-          secretAccessKey: process.env.S3_SECRET_ACCESS_KEY!,
-        },
-      }),
-    });
+    };
+    if (process.env.S3_ACCESS_KEY_ID && process.env.S3_SECRET_ACCESS_KEY) {
+      config.credentials = {
+        accessKeyId: process.env.S3_ACCESS_KEY_ID,
+        secretAccessKey: process.env.S3_SECRET_ACCESS_KEY,
+      };
+    }
+    this.client = new S3Client(config);
     this.bucketName = process.env.S3_BUCKET_NAME;
   }
 

--- a/apiUtils/storage/S3IamStorage.ts
+++ b/apiUtils/storage/S3IamStorage.ts
@@ -1,0 +1,140 @@
+import {
+  S3Client,
+  GetObjectCommand,
+  HeadObjectCommand,
+  ListObjectsV2Command,
+  PutObjectCommand,
+  CopyObjectCommand,
+} from '@aws-sdk/client-s3';
+import { StorageInterface } from './StorageInterface';
+
+export class S3IamStorage implements StorageInterface {
+  private client: S3Client;
+  private bucketName: string;
+
+  constructor() {
+    if (!process.env.S3_BUCKET_NAME) {
+      throw new Error('S3 bucket name not configured');
+    }
+
+    const hasExplicitCredentials =
+      process.env.S3_ACCESS_KEY_ID && process.env.S3_SECRET_ACCESS_KEY;
+
+    this.client = new S3Client({
+      region: process.env.S3_REGION ?? 'auto',
+      endpoint: process.env.S3_ENDPOINT,
+      ...(hasExplicitCredentials && {
+        credentials: {
+          accessKeyId: process.env.S3_ACCESS_KEY_ID!,
+          secretAccessKey: process.env.S3_SECRET_ACCESS_KEY!,
+        },
+      }),
+    });
+    this.bucketName = process.env.S3_BUCKET_NAME;
+  }
+
+  async copyFile(sourcePath: string, destinationPath: string): Promise<void> {
+    const copyCommand = new CopyObjectCommand({
+      Bucket: this.bucketName,
+      CopySource: sourcePath,
+      Key: destinationPath,
+    });
+    await this.client.send(copyCommand);
+  }
+
+  async downloadFile(path: string): Promise<Buffer> {
+    const getCommand = new GetObjectCommand({
+      Bucket: this.bucketName,
+      Key: path,
+    });
+    const response = await this.client.send(getCommand);
+    const body = await response.Body?.transformToByteArray();
+    if (!body) {
+      throw new Error('No body found in response');
+    }
+    return Buffer.from(body);
+  }
+
+  async fileExists(path: string): Promise<boolean> {
+    try {
+      const files = await this.listDirectories(path);
+      if (files.length > 0) {
+        return true;
+      }
+    } catch {}
+    try {
+      const headCommand = new HeadObjectCommand({
+        Bucket: this.bucketName,
+        Key: path.split('/').shift(),
+      });
+      await this.client.send(headCommand);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async listFiles(directory: string): Promise<
+    {
+      name: string;
+      updated_at: string;
+      created_at: string;
+      metadata: { size: number; mimetype: string };
+    }[]
+  > {
+    const prefix = `${directory}/`;
+    const listCommand = new ListObjectsV2Command({
+      Bucket: this.bucketName,
+      Prefix: prefix,
+    });
+    const response = await this.client.send(listCommand);
+    return (
+      response.Contents?.map((file) => ({
+        name: file.Key!.replace(prefix, ''),
+        updated_at: file.LastModified?.toISOString() ?? '',
+        created_at: file.LastModified?.toISOString() ?? '',
+        metadata: {
+          size: file.Size ?? 0,
+          mimetype: this.getMimeType(file.Key?.split('.').pop() ?? 'unknown'),
+        },
+      })) ?? []
+    );
+  }
+
+  async listDirectories(directory: string): Promise<string[]> {
+    const listCommand = new ListObjectsV2Command({
+      Bucket: this.bucketName,
+      Prefix: directory,
+      Delimiter: '/',
+    });
+    const response = await this.client.send(listCommand);
+    return (
+      response.CommonPrefixes?.map((prefix) =>
+        prefix.Prefix!.replace(directory, '').replace(/\/$/, '')
+      ) ?? []
+    );
+  }
+
+  async uploadFile(path: string, file: Buffer): Promise<string> {
+    const uploadCommand = new PutObjectCommand({
+      Bucket: this.bucketName,
+      Key: path,
+      Body: file,
+    });
+    await this.client.send(uploadCommand);
+    return path;
+  }
+
+  private getMimeType(ext: string): string {
+    const mimeTypes: { [key: string]: string } = {
+      js: 'application/javascript',
+      json: 'application/json',
+      png: 'image/png',
+      jpg: 'image/jpeg',
+      jpeg: 'image/jpeg',
+      gif: 'image/gif',
+      zip: 'application/zip',
+    };
+    return mimeTypes[ext.toLowerCase()] || 'application/octet-stream';
+  }
+}

--- a/apiUtils/storage/StorageFactory.ts
+++ b/apiUtils/storage/StorageFactory.ts
@@ -3,6 +3,7 @@ import { StorageInterface } from './StorageInterface';
 import { SupabaseStorage } from './SupabaseStorage';
 import { GCSStorage } from './GCSStorage';
 import { S3Storage } from './S3Storage';
+import { S3IamStorage } from './S3IamStorage';
 import { getLogger } from '../logger';
 
 const logger = getLogger('StorageFactory');
@@ -21,6 +22,8 @@ export class StorageFactory {
         StorageFactory.instance = new GCSStorage();
       } else if (storageType === 's3') {
         StorageFactory.instance = new S3Storage();
+      } else if (storageType === 's3-iam') {
+        StorageFactory.instance = new S3IamStorage();
       } else {
         logger.error('Unsupported storage type', { storageType });
         throw new Error('Unsupported storage type');

--- a/docs/supportedStorageAlternatives.md
+++ b/docs/supportedStorageAlternatives.md
@@ -41,6 +41,21 @@ S3_BUCKET_NAME=your-s3-bucket-name
 - Support all S3 compatible storage (AWS S3, Digital Ocean Spaces, Cloudflare R2, etc.)
 - Bucket should be created manually before starting the server
 
+### AWS S3 with IAM Credentials
+```env
+BLOB_STORAGE_TYPE=s3-iam
+S3_REGION=us-east-1
+S3_ENDPOINT=your-s3-endpoint
+S3_BUCKET_NAME=your-s3-bucket-name
+S3_ACCESS_KEY_ID=your-access-key-id     # optional
+S3_SECRET_ACCESS_KEY=your-secret-key    # optional
+```
+- Same S3 functionality but with optional access keys
+- When `S3_ACCESS_KEY_ID` and `S3_SECRET_ACCESS_KEY` are omitted, the AWS SDK resolves credentials automatically via the [default credential provider chain](https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/setting-credentials-node.html) (IAM roles, instance profiles, ECS task roles, EC2 metadata, SSO, etc.)
+- When access keys are provided, they are used explicitly (same behavior as the `s3` type)
+- Recommended for AWS-hosted deployments where IAM roles are available
+- Bucket should be created manually before starting the server
+
 ## Supported Database Providers
 Database configuration is managed via `DB_TYPE`.
 


### PR DESCRIPTION
## Description
- **feat: Added S3 Storage type that supports using the default IAM credential chain, on top of being able to use access keys**
- **feat: Added test case for the new s3 storage provider**

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Testing
- Added `__tests__/s3IamStorage.test.ts` for targeted S3 testing

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
