### PR TITLE
fix(assets): scope /api/assets to the release resolved by the manifest

### DIFF
--- a/.env.example.local
+++ b/.env.example.local
@@ -15,6 +15,10 @@ PRIVATE_KEY_BASE_64='your-private-key-in-base-64'
 # Password for admin access to the application UI
 ADMIN_PASSWORD=your-admin-password
 
+# Secret used to HMAC-sign the admin session cookie. Must be a long random string.
+# Rotating this value invalidates all current admin sessions.
+SESSION_SECRET=replace-with-a-long-random-string
+
 # Upload key to verify uploader has right to publish updates
 # Change this to a strong password in production
 UPLOAD_KEY=abc123def456

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -15,6 +15,10 @@ PRIVATE_KEY_BASE_64='your-base64-encoded-private-key'
 # Change this to a strong password in production
 ADMIN_PASSWORD=your-admin-password
 
+# Secret used to HMAC-sign the admin session cookie. Must be a long random string.
+# Rotating this value invalidates all current admin sessions.
+SESSION_SECRET=replace-with-a-long-random-string
+
 # Upload key to verify uploader has right to publish updates
 # Change this to a strong password in production
 UPLOAD_KEY=abc123def456

--- a/.jest/setEnvVars.js
+++ b/.jest/setEnvVars.js
@@ -1,3 +1,5 @@
 process.env.HOSTNAME = 'http://localhost:3001';
 process.env.DB_TYPE = 'postgres';
 process.env.UPLOAD_KEY = 'abc123def456';
+process.env.SESSION_SECRET = 'test-secret-do-not-use-in-prod';
+process.env.ADMIN_PASSWORD = 'test-admin-password';

--- a/__tests__/__snapshots__/assets.test.ts.snap
+++ b/__tests__/__snapshots__/assets.test.ts.snap
@@ -1,3 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`Assets API should serve asset successfully 1`] = `""`;

--- a/__tests__/__snapshots__/upload.test.ts.snap
+++ b/__tests__/__snapshots__/upload.test.ts.snap
@@ -9,7 +9,7 @@ Object {
 
 exports[`Upload API should return 400 for missing required fields 1`] = `
 Object {
-  "error": "Missing upload key, file, runtime version or commit hash",
+  "error": "Missing file, runtime version or commit hash",
 }
 `;
 

--- a/__tests__/__snapshots__/upload.test.ts.snap
+++ b/__tests__/__snapshots__/upload.test.ts.snap
@@ -2,8 +2,10 @@
 
 exports[`Upload API should handle file upload successfully 1`] = `
 Object {
+  "commitHash": "abc123",
   "path": "updates/1.0.0/timestamp.zip",
   "success": true,
+  "updateId": "abcdef12-3456-7890-abcd-ef1234567890",
 }
 `;
 

--- a/__tests__/assets.test.ts
+++ b/__tests__/assets.test.ts
@@ -1,46 +1,111 @@
 import { createMocks } from 'node-mocks-http';
 
+import { DatabaseFactory } from '../apiUtils/database/DatabaseFactory';
+import { DatabaseInterface, Release } from '../apiUtils/database/DatabaseInterface';
 import { UpdateHelper } from '../apiUtils/helpers/UpdateHelper';
 import { ZipHelper } from '../apiUtils/helpers/ZipHelper';
 import assetsEndpoint from '../pages/api/assets';
 
 jest.mock('../apiUtils/helpers/UpdateHelper');
 jest.mock('../apiUtils/helpers/ZipHelper');
+jest.mock('../apiUtils/database/DatabaseFactory');
+
+const baseRelease: Release = {
+  id: 'release-id-42',
+  runtimeVersion: '1.0.0',
+  path: 'updates/1.0.0/12345.zip',
+  timestamp: '2024-03-20T00:00:00Z',
+  commitHash: 'abc',
+  commitMessage: 'msg',
+  updateId: 'uid-1',
+  updateGroupId: 'g-prod',
+};
 
 describe('Assets API', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('should return 400 if asset path is missing', async () => {
+  it('returns 400 when asset path is missing', async () => {
     const { req, res } = createMocks({
       method: 'GET',
-      query: {
-        platform: 'ios',
-        runtimeVersion: '1.0.0',
-      },
+      query: { platform: 'ios', runtimeVersion: '1.0.0', releaseId: 'release-id-42' },
     });
-
     await assetsEndpoint(req, res);
     expect(res._getStatusCode()).toBe(400);
   });
 
-  it('should return 400 if platform is invalid', async () => {
+  it('returns 400 when platform is invalid', async () => {
     const { req, res } = createMocks({
       method: 'GET',
       query: {
         asset: 'test.png',
         platform: 'web',
         runtimeVersion: '1.0.0',
+        releaseId: 'release-id-42',
       },
     });
-
     await assetsEndpoint(req, res);
     expect(res._getStatusCode()).toBe(400);
   });
 
-  it('should serve asset successfully', async () => {
-    const mockMetadata = {
+  it('returns 400 when releaseId is missing (e.g. stale pre-deploy manifest)', async () => {
+    const { req, res } = createMocks({
+      method: 'GET',
+      query: {
+        asset: 'test.png',
+        platform: 'ios',
+        runtimeVersion: '1.0.0',
+      },
+    });
+    await assetsEndpoint(req, res);
+    expect(res._getStatusCode()).toBe(400);
+    expect(JSON.parse(res._getData())).toEqual({ error: 'No releaseId provided.' });
+  });
+
+  it('returns 404 when releaseId does not match any release', async () => {
+    (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue({
+      getRelease: jest.fn().mockResolvedValue(null),
+    } as unknown as DatabaseInterface);
+
+    const { req, res } = createMocks({
+      method: 'GET',
+      query: {
+        asset: 'test.png',
+        platform: 'ios',
+        runtimeVersion: '1.0.0',
+        releaseId: 'unknown',
+      },
+    });
+    await assetsEndpoint(req, res);
+    expect(res._getStatusCode()).toBe(404);
+  });
+
+  it("returns 400 when the release's runtimeVersion does not match the query", async () => {
+    (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue({
+      getRelease: jest.fn().mockResolvedValue({ ...baseRelease, runtimeVersion: '2.0.0' }),
+    } as unknown as DatabaseInterface);
+
+    const { req, res } = createMocks({
+      method: 'GET',
+      query: {
+        asset: 'test.png',
+        platform: 'ios',
+        runtimeVersion: '1.0.0',
+        releaseId: 'release-id-42',
+      },
+    });
+    await assetsEndpoint(req, res);
+    expect(res._getStatusCode()).toBe(400);
+  });
+
+  it('serves the asset from the resolved release bundle', async () => {
+    const getRelease = jest.fn().mockResolvedValue(baseRelease);
+    (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue({
+      getRelease,
+    } as unknown as DatabaseInterface);
+
+    (UpdateHelper.getMetadataAsync as jest.Mock).mockResolvedValue({
       metadataJson: {
         fileMetadata: {
           ios: {
@@ -49,12 +114,7 @@ describe('Assets API', () => {
           },
         },
       },
-    };
-
-    (UpdateHelper.getLatestUpdateBundlePathForRuntimeVersionAsync as jest.Mock).mockResolvedValue(
-      'path/to/update'
-    );
-    (UpdateHelper.getMetadataAsync as jest.Mock).mockResolvedValue(mockMetadata);
+    });
     (ZipHelper.getZipFromStorage as jest.Mock).mockResolvedValue({});
     (ZipHelper.getFileFromZip as jest.Mock).mockResolvedValue(Buffer.from('test'));
 
@@ -64,11 +124,17 @@ describe('Assets API', () => {
         asset: 'test.png',
         platform: 'ios',
         runtimeVersion: '1.0.0',
+        releaseId: 'release-id-42',
       },
     });
-
     await assetsEndpoint(req, res);
+
     expect(res._getStatusCode()).toBe(200);
-    expect(res._getData()).toMatchSnapshot();
+    expect(getRelease).toHaveBeenCalledWith('release-id-42');
+    // Path is the zip path with the `.zip` suffix stripped — same shape the
+    // manifest endpoint feeds to the storage layer.
+    expect(UpdateHelper.getMetadataAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ updateBundlePath: 'updates/1.0.0/12345' })
+    );
   });
 });

--- a/__tests__/helpers/session.ts
+++ b/__tests__/helpers/session.ts
@@ -1,0 +1,5 @@
+import { generateSessionValue, SESSION_COOKIE } from '../../apiUtils/auth/session';
+
+export function authedCookies(): Record<string, string> {
+  return { [SESSION_COOKIE]: generateSessionValue() };
+}

--- a/__tests__/manifest.test.ts
+++ b/__tests__/manifest.test.ts
@@ -353,7 +353,7 @@ describe('Manifest API', () => {
     expect(UpdateHelper.createNoUpdateAvailableDirectiveAsync).toHaveBeenCalled();
   });
 
-  it('passes xavia-user-id to the resolver', async () => {
+  it('passes xavia-user-id (from Expo-Extra-Params) to the resolver', async () => {
     const mockRelease = {
       id: 'release-id',
       runtimeVersion: '1.0.0',
@@ -380,7 +380,7 @@ describe('Manifest API', () => {
         'expo-runtime-version': '1.0.0',
         'expo-protocol-version': '1',
         'expo-current-update-id': 'uid-1',
-        'xavia-user-id': 'user-42',
+        'expo-extra-params': 'xavia-user-id="user-42"',
       },
     });
 
@@ -389,7 +389,51 @@ describe('Manifest API', () => {
     expect(getLatestReleaseForUser).toHaveBeenCalledWith('1.0.0', 'user-42');
   });
 
-  it('treats missing xavia-user-id as anonymous (null userId)', async () => {
+  it('ignores unknown Expo-Extra-Params keys', async () => {
+    const getLatestReleaseForUser = jest.fn().mockResolvedValue(null);
+    (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue({ getLatestReleaseForUser });
+    (UpdateHelper.getResolvedUpdateBundlePathAsync as jest.Mock) = jest
+      .fn()
+      .mockRejectedValue(new NoUpdateAvailableError());
+
+    const { req, res } = createMocks({
+      method: 'GET',
+      headers: {
+        'expo-platform': 'ios',
+        'expo-runtime-version': '1.0.0',
+        'expo-protocol-version': '1',
+        'expo-extra-params': 'some-other-key="x", another="y"',
+      },
+    });
+
+    await manifestEndpoint(req, res);
+
+    expect(getLatestReleaseForUser).toHaveBeenCalledWith('1.0.0', null);
+  });
+
+  it('treats malformed Expo-Extra-Params as anonymous', async () => {
+    const getLatestReleaseForUser = jest.fn().mockResolvedValue(null);
+    (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue({ getLatestReleaseForUser });
+    (UpdateHelper.getResolvedUpdateBundlePathAsync as jest.Mock) = jest
+      .fn()
+      .mockRejectedValue(new NoUpdateAvailableError());
+
+    const { req, res } = createMocks({
+      method: 'GET',
+      headers: {
+        'expo-platform': 'ios',
+        'expo-runtime-version': '1.0.0',
+        'expo-protocol-version': '1',
+        'expo-extra-params': 'this is not a valid dictionary!!!',
+      },
+    });
+
+    await manifestEndpoint(req, res);
+
+    expect(getLatestReleaseForUser).toHaveBeenCalledWith('1.0.0', null);
+  });
+
+  it('treats missing Expo-Extra-Params as anonymous (null userId)', async () => {
     const getLatestReleaseForUser = jest.fn().mockResolvedValue(null);
     (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue({
       getLatestReleaseForUser,

--- a/__tests__/manifest.test.ts
+++ b/__tests__/manifest.test.ts
@@ -64,10 +64,11 @@ describe('Manifest API', () => {
       commitHash: 'abc123',
       commitMessage: 'Test commit',
       updateId: 'test-update-id',
+      updateGroupId: 'g-prod',
     };
 
     const mockDatabase = {
-      getLatestReleaseRecordForRuntimeVersion: jest.fn().mockResolvedValue(mockRelease),
+      getLatestReleaseForUser: jest.fn().mockResolvedValue(mockRelease),
     } as unknown as DatabaseInterface;
 
     (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue(mockDatabase);
@@ -117,10 +118,11 @@ describe('Manifest API', () => {
       commitHash: 'abc123',
       commitMessage: 'Test commit',
       updateId: 'different-update-id',
+      updateGroupId: 'g-prod',
     };
 
     const mockDatabase = {
-      getLatestReleaseRecordForRuntimeVersion: jest.fn().mockResolvedValue(mockRelease),
+      getLatestReleaseForUser: jest.fn().mockResolvedValue(mockRelease),
       getReleaseByPath: jest.fn().mockResolvedValue(mockRelease),
       createTracking: jest.fn().mockResolvedValue(undefined),
     } as unknown as DatabaseInterface;
@@ -145,7 +147,7 @@ describe('Manifest API', () => {
     (HashHelper.convertSHA256HashToUUID as jest.Mock).mockReturnValue(mockUUID);
 
     // Mock UpdateHelper methods
-    (UpdateHelper.getLatestUpdateBundlePathForRuntimeVersionAsync as jest.Mock).mockResolvedValue(
+    (UpdateHelper.getResolvedUpdateBundlePathAsync as jest.Mock).mockResolvedValue(
       'path/to/update'
     );
     (UpdateHelper.getMetadataAsync as jest.Mock).mockResolvedValue(mockMetadata);
@@ -198,13 +200,13 @@ describe('Manifest API', () => {
   it('should handle rollback update successfully', async () => {
     // Mock database
     const mockDatabase = {
-      getLatestReleaseRecordForRuntimeVersion: jest.fn().mockResolvedValue(null),
+      getLatestReleaseForUser: jest.fn().mockResolvedValue(null),
     } as unknown as DatabaseInterface;
 
     (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue(mockDatabase);
 
     // Mock UpdateHelper methods
-    (UpdateHelper.getLatestUpdateBundlePathForRuntimeVersionAsync as jest.Mock).mockResolvedValue(
+    (UpdateHelper.getResolvedUpdateBundlePathAsync as jest.Mock).mockResolvedValue(
       'path/to/update'
     );
     (UpdateHelper.createRollBackDirectiveAsync as jest.Mock).mockResolvedValue({
@@ -253,13 +255,13 @@ describe('Manifest API', () => {
   it('should return NoUpdateAvailable when current update matches latest', async () => {
     // Mock database
     const mockDatabase = {
-      getLatestReleaseRecordForRuntimeVersion: jest.fn().mockResolvedValue(null),
+      getLatestReleaseForUser: jest.fn().mockResolvedValue(null),
     } as unknown as DatabaseInterface;
 
     (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue(mockDatabase);
 
     // Mock UpdateHelper methods
-    (UpdateHelper.getLatestUpdateBundlePathForRuntimeVersionAsync as jest.Mock).mockResolvedValue(
+    (UpdateHelper.getResolvedUpdateBundlePathAsync as jest.Mock).mockResolvedValue(
       'path/to/update'
     );
 
@@ -312,13 +314,13 @@ describe('Manifest API', () => {
   it('should handle NoUpdateAvailable error from UpdateHelper', async () => {
     // Mock database
     const mockDatabase = {
-      getLatestReleaseRecordForRuntimeVersion: jest.fn().mockResolvedValue(null),
+      getLatestReleaseForUser: jest.fn().mockResolvedValue(null),
     } as unknown as DatabaseInterface;
 
     (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue(mockDatabase);
 
     // Mock UpdateHelper to throw NoUpdateAvailableError
-    (UpdateHelper.getLatestUpdateBundlePathForRuntimeVersionAsync as jest.Mock).mockRejectedValue(
+    (UpdateHelper.getResolvedUpdateBundlePathAsync as jest.Mock).mockRejectedValue(
       new NoUpdateAvailableError()
     );
 
@@ -349,5 +351,64 @@ describe('Manifest API', () => {
 
     expect(res._getStatusCode()).toBe(200);
     expect(UpdateHelper.createNoUpdateAvailableDirectiveAsync).toHaveBeenCalled();
+  });
+
+  it('passes xavia-user-id to the resolver', async () => {
+    const mockRelease = {
+      id: 'release-id',
+      runtimeVersion: '1.0.0',
+      path: 'updates/1.0.0/x.zip',
+      timestamp: '2024-03-20T00:00:00Z',
+      commitHash: 'abc',
+      commitMessage: 'msg',
+      updateId: 'uid-1',
+      updateGroupId: 'g-beta',
+    };
+    const getLatestReleaseForUser = jest.fn().mockResolvedValue(mockRelease);
+    (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue({
+      getLatestReleaseForUser,
+    });
+
+    (UpdateHelper.getResolvedUpdateBundlePathAsync as jest.Mock) = jest
+      .fn()
+      .mockResolvedValue('updates/1.0.0/x');
+
+    const { req, res } = createMocks({
+      method: 'GET',
+      headers: {
+        'expo-platform': 'ios',
+        'expo-runtime-version': '1.0.0',
+        'expo-protocol-version': '1',
+        'expo-current-update-id': 'uid-1',
+        'xavia-user-id': 'user-42',
+      },
+    });
+
+    await manifestEndpoint(req, res);
+
+    expect(getLatestReleaseForUser).toHaveBeenCalledWith('1.0.0', 'user-42');
+  });
+
+  it('treats missing xavia-user-id as anonymous (null userId)', async () => {
+    const getLatestReleaseForUser = jest.fn().mockResolvedValue(null);
+    (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue({
+      getLatestReleaseForUser,
+    });
+    (UpdateHelper.getResolvedUpdateBundlePathAsync as jest.Mock) = jest
+      .fn()
+      .mockRejectedValue(new NoUpdateAvailableError());
+
+    const { req, res } = createMocks({
+      method: 'GET',
+      headers: {
+        'expo-platform': 'ios',
+        'expo-runtime-version': '1.0.0',
+        'expo-protocol-version': '1',
+      },
+    });
+
+    await manifestEndpoint(req, res);
+
+    expect(getLatestReleaseForUser).toHaveBeenCalledWith('1.0.0', null);
   });
 });

--- a/__tests__/manifest.test.ts
+++ b/__tests__/manifest.test.ts
@@ -3,7 +3,7 @@ import { createMocks } from 'node-mocks-http';
 import FormData from 'form-data';
 
 import { ConfigHelper } from '../apiUtils/helpers/ConfigHelper';
-import { UpdateHelper, NoUpdateAvailableError } from '../apiUtils/helpers/UpdateHelper';
+import { UpdateHelper } from '../apiUtils/helpers/UpdateHelper';
 import { ZipHelper } from '../apiUtils/helpers/ZipHelper';
 import { HashHelper } from '../apiUtils/helpers/HashHelper';
 import manifestEndpoint from '../pages/api/manifest';
@@ -55,7 +55,6 @@ describe('Manifest API', () => {
   });
 
   it('should return NoUpdateAvailable when user is already running the latest release', async () => {
-    // Mock database to return a release with matching updateId
     const mockRelease: Release = {
       id: 'release-id',
       runtimeVersion: '1.0.0',
@@ -73,13 +72,11 @@ describe('Manifest API', () => {
 
     (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue(mockDatabase);
 
-    // Mock NoUpdateAvailable directive
     const mockNoUpdateDirective = { type: 'noUpdateAvailable' };
     (UpdateHelper.createNoUpdateAvailableDirectiveAsync as jest.Mock).mockResolvedValue(
       mockNoUpdateDirective
     );
 
-    // Mock FormData
     const mockFormData = {
       append: jest.fn(),
       getBoundary: jest.fn().mockReturnValue('boundary'),
@@ -108,10 +105,9 @@ describe('Manifest API', () => {
     );
   });
 
-  it('should handle normal update successfully', async () => {
-    // Mock database to return a release with different updateId
+  it('should handle normal update successfully and pass releaseId to asset metadata', async () => {
     const mockRelease: Release = {
-      id: 'release-id',
+      id: 'release-id-42',
       runtimeVersion: '1.0.0',
       path: 'path/to/update.zip',
       timestamp: '2024-03-20T00:00:00Z',
@@ -123,7 +119,6 @@ describe('Manifest API', () => {
 
     const mockDatabase = {
       getLatestReleaseForUser: jest.fn().mockResolvedValue(mockRelease),
-      getReleaseByPath: jest.fn().mockResolvedValue(mockRelease),
       createTracking: jest.fn().mockResolvedValue(undefined),
     } as unknown as DatabaseInterface;
 
@@ -142,14 +137,9 @@ describe('Manifest API', () => {
       id: 'test-id',
     };
 
-    // Mock UUID conversion
     const mockUUID = 'test-uuid';
     (HashHelper.convertSHA256HashToUUID as jest.Mock).mockReturnValue(mockUUID);
 
-    // Mock UpdateHelper methods
-    (UpdateHelper.getResolvedUpdateBundlePathAsync as jest.Mock).mockResolvedValue(
-      'path/to/update'
-    );
     (UpdateHelper.getMetadataAsync as jest.Mock).mockResolvedValue(mockMetadata);
     (UpdateHelper.getAssetMetadataAsync as jest.Mock).mockResolvedValue({
       hash: 'hash',
@@ -159,16 +149,13 @@ describe('Manifest API', () => {
       url: 'url',
     });
 
-    // Mock ConfigHelper
     (ConfigHelper.getExpoConfigAsync as jest.Mock).mockResolvedValue({});
 
-    // Mock ZipHelper
     const mockZip = {
       getEntry: jest.fn().mockReturnValue(null),
     };
     (ZipHelper.getZipFromStorage as jest.Mock).mockResolvedValue(mockZip as unknown as AdmZip);
 
-    // Mock FormData
     const mockFormData = {
       append: jest.fn(),
       getBoundary: jest.fn().mockReturnValue('boundary'),
@@ -182,14 +169,19 @@ describe('Manifest API', () => {
         'expo-platform': 'ios',
         'expo-runtime-version': '1.0.0',
         'expo-protocol-version': '1',
-        'expo-current-update-id': 'current-update-id', // Different from the release updateId
+        'expo-current-update-id': 'current-update-id',
       },
     });
 
     await manifestEndpoint(req, res);
 
     expect(res._getStatusCode()).toBe(200);
-    expect(mockDatabase.createTracking).toHaveBeenCalled();
+    expect(mockDatabase.createTracking).toHaveBeenCalledWith(
+      expect.objectContaining({ releaseId: 'release-id-42', platform: 'ios' })
+    );
+    expect(UpdateHelper.getAssetMetadataAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ releaseId: 'release-id-42', updateBundlePath: 'path/to/update' })
+    );
     expect(mockFormData.append).toHaveBeenCalledWith(
       'manifest',
       expect.any(String),
@@ -198,17 +190,22 @@ describe('Manifest API', () => {
   });
 
   it('should handle rollback update successfully', async () => {
-    // Mock database
+    const mockRelease: Release = {
+      id: 'release-id',
+      runtimeVersion: '1.0.0',
+      path: 'path/to/update.zip',
+      timestamp: '2024-03-20T00:00:00Z',
+      commitHash: 'abc',
+      commitMessage: 'msg',
+      updateId: 'uid-1',
+      updateGroupId: 'g-prod',
+    };
     const mockDatabase = {
-      getLatestReleaseForUser: jest.fn().mockResolvedValue(null),
+      getLatestReleaseForUser: jest.fn().mockResolvedValue(mockRelease),
     } as unknown as DatabaseInterface;
 
     (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue(mockDatabase);
 
-    // Mock UpdateHelper methods
-    (UpdateHelper.getResolvedUpdateBundlePathAsync as jest.Mock).mockResolvedValue(
-      'path/to/update'
-    );
     (UpdateHelper.createRollBackDirectiveAsync as jest.Mock).mockResolvedValue({
       type: 'rollBackToEmbedded',
       parameters: {
@@ -216,13 +213,11 @@ describe('Manifest API', () => {
       },
     });
 
-    // Mock ZipHelper to indicate rollback
     const mockZip = {
-      getEntry: jest.fn().mockReturnValue({ name: 'rollback' }), // Return non-null to indicate rollback
+      getEntry: jest.fn().mockReturnValue({ name: 'rollback' }),
     };
     (ZipHelper.getZipFromStorage as jest.Mock).mockResolvedValue(mockZip as unknown as AdmZip);
 
-    // Mock FormData
     const mockFormData = {
       append: jest.fn(),
       getBoundary: jest.fn().mockReturnValue('boundary'),
@@ -253,17 +248,21 @@ describe('Manifest API', () => {
   });
 
   it('should return NoUpdateAvailable when current update matches latest', async () => {
-    // Mock database
+    const mockRelease: Release = {
+      id: 'release-id',
+      runtimeVersion: '1.0.0',
+      path: 'path/to/update.zip',
+      timestamp: '2024-03-20T00:00:00Z',
+      commitHash: 'abc',
+      commitMessage: 'msg',
+      updateId: 'uid-stored',
+      updateGroupId: 'g-prod',
+    };
     const mockDatabase = {
-      getLatestReleaseForUser: jest.fn().mockResolvedValue(null),
+      getLatestReleaseForUser: jest.fn().mockResolvedValue(mockRelease),
     } as unknown as DatabaseInterface;
 
     (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue(mockDatabase);
-
-    // Mock UpdateHelper methods
-    (UpdateHelper.getResolvedUpdateBundlePathAsync as jest.Mock).mockResolvedValue(
-      'path/to/update'
-    );
 
     const mockMetadata = {
       metadataJson: { fileMetadata: { ios: {} } },
@@ -272,22 +271,19 @@ describe('Manifest API', () => {
     };
     (UpdateHelper.getMetadataAsync as jest.Mock).mockResolvedValue(mockMetadata);
 
-    // Mock UUID conversion to match current update ID
+    // Hash matches the request's expo-current-update-id → fall into NoUpdateAvailable
     (HashHelper.convertSHA256HashToUUID as jest.Mock).mockReturnValue('current-update-id');
 
-    // Mock NoUpdateAvailable directive
     const mockNoUpdateDirective = { type: 'noUpdateAvailable' };
     (UpdateHelper.createNoUpdateAvailableDirectiveAsync as jest.Mock).mockResolvedValue(
       mockNoUpdateDirective
     );
 
-    // Mock ZipHelper
     const mockZip = {
-      getEntry: jest.fn().mockReturnValue(null), // Not a rollback
+      getEntry: jest.fn().mockReturnValue(null),
     };
     (ZipHelper.getZipFromStorage as jest.Mock).mockResolvedValue(mockZip as unknown as AdmZip);
 
-    // Mock FormData
     const mockFormData = {
       append: jest.fn(),
       getBoundary: jest.fn().mockReturnValue('boundary'),
@@ -301,7 +297,7 @@ describe('Manifest API', () => {
         'expo-platform': 'ios',
         'expo-runtime-version': '1.0.0',
         'expo-protocol-version': '1',
-        'expo-current-update-id': 'current-update-id', // Will match the converted hash
+        'expo-current-update-id': 'current-update-id',
       },
     });
 
@@ -311,26 +307,18 @@ describe('Manifest API', () => {
     expect(UpdateHelper.createNoUpdateAvailableDirectiveAsync).toHaveBeenCalled();
   });
 
-  it('should handle NoUpdateAvailable error from UpdateHelper', async () => {
-    // Mock database
+  it('should return NoUpdateAvailable when resolver finds no release for the runtime version', async () => {
     const mockDatabase = {
       getLatestReleaseForUser: jest.fn().mockResolvedValue(null),
     } as unknown as DatabaseInterface;
 
     (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue(mockDatabase);
 
-    // Mock UpdateHelper to throw NoUpdateAvailableError
-    (UpdateHelper.getResolvedUpdateBundlePathAsync as jest.Mock).mockRejectedValue(
-      new NoUpdateAvailableError()
-    );
-
-    // Mock NoUpdateAvailable directive
     const mockNoUpdateDirective = { type: 'noUpdateAvailable' };
     (UpdateHelper.createNoUpdateAvailableDirectiveAsync as jest.Mock).mockResolvedValue(
       mockNoUpdateDirective
     );
 
-    // Mock FormData
     const mockFormData = {
       append: jest.fn(),
       getBoundary: jest.fn().mockReturnValue('boundary'),
@@ -354,7 +342,7 @@ describe('Manifest API', () => {
   });
 
   it('passes xavia-user-id (from Expo-Extra-Params) to the resolver', async () => {
-    const mockRelease = {
+    const mockRelease: Release = {
       id: 'release-id',
       runtimeVersion: '1.0.0',
       path: 'updates/1.0.0/x.zip',
@@ -368,10 +356,6 @@ describe('Manifest API', () => {
     (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue({
       getLatestReleaseForUser,
     });
-
-    (UpdateHelper.getResolvedUpdateBundlePathAsync as jest.Mock) = jest
-      .fn()
-      .mockResolvedValue('updates/1.0.0/x');
 
     const { req, res } = createMocks({
       method: 'GET',
@@ -392,9 +376,6 @@ describe('Manifest API', () => {
   it('ignores unknown Expo-Extra-Params keys', async () => {
     const getLatestReleaseForUser = jest.fn().mockResolvedValue(null);
     (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue({ getLatestReleaseForUser });
-    (UpdateHelper.getResolvedUpdateBundlePathAsync as jest.Mock) = jest
-      .fn()
-      .mockRejectedValue(new NoUpdateAvailableError());
 
     const { req, res } = createMocks({
       method: 'GET',
@@ -414,9 +395,6 @@ describe('Manifest API', () => {
   it('treats malformed Expo-Extra-Params as anonymous', async () => {
     const getLatestReleaseForUser = jest.fn().mockResolvedValue(null);
     (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue({ getLatestReleaseForUser });
-    (UpdateHelper.getResolvedUpdateBundlePathAsync as jest.Mock) = jest
-      .fn()
-      .mockRejectedValue(new NoUpdateAvailableError());
 
     const { req, res } = createMocks({
       method: 'GET',
@@ -438,9 +416,6 @@ describe('Manifest API', () => {
     (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue({
       getLatestReleaseForUser,
     });
-    (UpdateHelper.getResolvedUpdateBundlePathAsync as jest.Mock) = jest
-      .fn()
-      .mockRejectedValue(new NoUpdateAvailableError());
 
     const { req, res } = createMocks({
       method: 'GET',
@@ -456,3 +431,4 @@ describe('Manifest API', () => {
     expect(getLatestReleaseForUser).toHaveBeenCalledWith('1.0.0', null);
   });
 });
+

--- a/__tests__/releases.test.ts
+++ b/__tests__/releases.test.ts
@@ -63,4 +63,39 @@ describe('Releases API', () => {
     expect(res._getStatusCode()).toBe(500);
     expect(JSON.parse(res._getData())).toMatchSnapshot();
   });
+
+  it('includes update group fields on each release', async () => {
+    const mockStorage = {
+      listDirectories: jest.fn().mockResolvedValue(['1.0.0']),
+      listFiles: jest.fn().mockResolvedValue([
+        { name: 'a.zip', created_at: 't', metadata: { size: 1 } },
+      ]),
+    };
+    const mockDatabase = {
+      listReleases: jest.fn().mockResolvedValue([
+        {
+          id: 'r1',
+          path: 'updates/1.0.0/a.zip',
+          runtimeVersion: '1.0.0',
+          timestamp: 't',
+          commitHash: 'h',
+          commitMessage: 'm',
+          updateGroupId: 'g-beta',
+          updateGroupName: 'beta',
+        },
+      ]),
+    };
+    (StorageFactory.getStorage as jest.Mock).mockReturnValue(mockStorage);
+    (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue(mockDatabase);
+
+    const { req, res } = createMocks({ method: 'GET' });
+    await releasesHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const { releases } = JSON.parse(res._getData());
+    expect(releases[0]).toEqual(expect.objectContaining({
+      updateGroupId: 'g-beta',
+      updateGroupName: 'beta',
+    }));
+  });
 });

--- a/__tests__/releases.test.ts
+++ b/__tests__/releases.test.ts
@@ -3,6 +3,7 @@ import { createMocks } from 'node-mocks-http';
 import { DatabaseFactory } from '../apiUtils/database/DatabaseFactory';
 import { StorageFactory } from '../apiUtils/storage/StorageFactory';
 import releasesHandler from '../pages/api/releases';
+import { authedCookies } from './helpers/session';
 
 jest.mock('../apiUtils/database/DatabaseFactory');
 jest.mock('../apiUtils/storage/StorageFactory');
@@ -17,6 +18,12 @@ describe('Releases API', () => {
     await releasesHandler(req, res);
     expect(res._getStatusCode()).toBe(405);
     expect(JSON.parse(res._getData())).toMatchSnapshot();
+  });
+
+  it('returns 401 without a valid session cookie', async () => {
+    const { req, res } = createMocks({ method: 'GET' });
+    await releasesHandler(req, res);
+    expect(res._getStatusCode()).toBe(401);
   });
 
   it('should return releases successfully', async () => {
@@ -43,7 +50,7 @@ describe('Releases API', () => {
     (StorageFactory.getStorage as jest.Mock).mockReturnValue(mockStorage);
     (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue(mockDatabase);
 
-    const { req, res } = createMocks({ method: 'GET' });
+    const { req, res } = createMocks({ method: 'GET', cookies: authedCookies() });
     await releasesHandler(req, res);
 
     expect(res._getStatusCode()).toBe(200);
@@ -57,7 +64,7 @@ describe('Releases API', () => {
 
     (StorageFactory.getStorage as jest.Mock).mockReturnValue(mockStorage);
 
-    const { req, res } = createMocks({ method: 'GET' });
+    const { req, res } = createMocks({ method: 'GET', cookies: authedCookies() });
     await releasesHandler(req, res);
 
     expect(res._getStatusCode()).toBe(500);
@@ -88,7 +95,7 @@ describe('Releases API', () => {
     (StorageFactory.getStorage as jest.Mock).mockReturnValue(mockStorage);
     (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue(mockDatabase);
 
-    const { req, res } = createMocks({ method: 'GET' });
+    const { req, res } = createMocks({ method: 'GET', cookies: authedCookies() });
     await releasesHandler(req, res);
 
     expect(res._getStatusCode()).toBe(200);

--- a/__tests__/rollback.test.ts
+++ b/__tests__/rollback.test.ts
@@ -3,6 +3,7 @@ import { createMocks } from 'node-mocks-http';
 import { DatabaseFactory } from '../apiUtils/database/DatabaseFactory';
 import { StorageFactory } from '../apiUtils/storage/StorageFactory';
 import rollbackHandler from '../pages/api/rollback';
+import { authedCookies } from './helpers/session';
 
 jest.mock('../apiUtils/database/DatabaseFactory');
 jest.mock('../apiUtils/storage/StorageFactory');
@@ -23,6 +24,7 @@ describe('Rollback API', () => {
     const { req, res } = createMocks({
       method: 'POST',
       body: {},
+      cookies: authedCookies(),
     });
     await rollbackHandler(req, res);
     expect(res._getStatusCode()).toBe(400);
@@ -62,6 +64,7 @@ describe('Rollback API', () => {
         runtimeVersion: '1.0.0',
         commitHash: 'abc123',
       },
+      cookies: authedCookies(),
     });
 
     await rollbackHandler(req, res);
@@ -99,6 +102,7 @@ describe('Rollback API', () => {
         commitHash: 'h',
         commitMessage: 'm',
       },
+      cookies: authedCookies(),
     });
     await rollbackHandler(req, res);
 
@@ -135,6 +139,7 @@ describe('Rollback API', () => {
         commitMessage: 'm',
         updateGroup: 'beta',
       },
+      cookies: authedCookies(),
     });
     await rollbackHandler(req, res);
 

--- a/__tests__/rollback.test.ts
+++ b/__tests__/rollback.test.ts
@@ -34,8 +34,20 @@ describe('Rollback API', () => {
       copyFile: jest.fn().mockResolvedValue(true),
     };
 
+    const createRelease = jest.fn().mockResolvedValue(true);
     const mockDatabase = {
-      createRelease: jest.fn().mockResolvedValue(true),
+      createRelease,
+      getReleaseByPath: jest.fn().mockResolvedValue({
+        id: 'r1',
+        path: 'updates/1.0.0/old.zip',
+        runtimeVersion: '1.0.0',
+        timestamp: 't',
+        commitHash: 'abc123',
+        commitMessage: '',
+        updateGroupId: 'g-default',
+      }),
+      getUpdateGroupByName: jest.fn(),
+      getDefaultUpdateGroup: jest.fn(),
     };
 
     (StorageFactory.getStorage as jest.Mock).mockReturnValue(mockStorage);
@@ -56,6 +68,77 @@ describe('Rollback API', () => {
     expect(res._getStatusCode()).toBe(200);
     expect(res._getData()).toMatchSnapshot();
     expect(mockStorage.copyFile).toHaveBeenCalled();
-    expect(mockDatabase.createRelease).toHaveBeenCalled();
+    expect(createRelease).toHaveBeenCalledWith(expect.objectContaining({ updateGroupId: 'g-default' }));
+  });
+
+  it('inherits the source release group when no override is provided', async () => {
+    const mockStorage = { copyFile: jest.fn().mockResolvedValue(undefined) };
+    const createRelease = jest.fn().mockResolvedValue({});
+    const mockDatabase = {
+      getReleaseByPath: jest.fn().mockResolvedValue({
+        id: 'r1',
+        path: 'updates/1.0.0/old.zip',
+        runtimeVersion: '1.0.0',
+        timestamp: 't',
+        commitHash: 'h',
+        commitMessage: 'm',
+        updateGroupId: 'g-beta',
+      }),
+      getUpdateGroupByName: jest.fn(),
+      getDefaultUpdateGroup: jest.fn(),
+      createRelease,
+    };
+    (StorageFactory.getStorage as jest.Mock).mockReturnValue(mockStorage);
+    (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue(mockDatabase);
+
+    const { req, res } = createMocks({
+      method: 'POST',
+      body: {
+        path: 'updates/1.0.0/old.zip',
+        runtimeVersion: '1.0.0',
+        commitHash: 'h',
+        commitMessage: 'm',
+      },
+    });
+    await rollbackHandler(req, res);
+
+    expect(createRelease).toHaveBeenCalledWith(expect.objectContaining({ updateGroupId: 'g-beta' }));
+  });
+
+  it('honors the updateGroup override', async () => {
+    const mockStorage = { copyFile: jest.fn().mockResolvedValue(undefined) };
+    const createRelease = jest.fn().mockResolvedValue({});
+    const mockDatabase = {
+      getReleaseByPath: jest.fn().mockResolvedValue({
+        id: 'r1',
+        path: 'updates/1.0.0/old.zip',
+        runtimeVersion: '1.0.0',
+        timestamp: 't',
+        commitHash: 'h',
+        commitMessage: 'm',
+        updateGroupId: 'g-prod',
+      }),
+      getUpdateGroupByName: jest.fn().mockResolvedValue({
+        id: 'g-beta', name: 'beta', isDefault: false, createdAt: 't',
+      }),
+      createRelease,
+    };
+    (StorageFactory.getStorage as jest.Mock).mockReturnValue(mockStorage);
+    (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue(mockDatabase);
+
+    const { req, res } = createMocks({
+      method: 'POST',
+      body: {
+        path: 'updates/1.0.0/old.zip',
+        runtimeVersion: '1.0.0',
+        commitHash: 'h',
+        commitMessage: 'm',
+        updateGroup: 'beta',
+      },
+    });
+    await rollbackHandler(req, res);
+
+    expect(mockDatabase.getUpdateGroupByName).toHaveBeenCalledWith('beta');
+    expect(createRelease).toHaveBeenCalledWith(expect.objectContaining({ updateGroupId: 'g-beta' }));
   });
 });

--- a/__tests__/updateGroupMembers.test.ts
+++ b/__tests__/updateGroupMembers.test.ts
@@ -37,7 +37,25 @@ describe('Update group members API', () => {
     });
     await membersHandler(req, res);
 
-    expect(db.addUserToGroup).toHaveBeenCalledWith('g1', 'u42');
+    expect(db.addUserToGroup).toHaveBeenCalledWith('g1', 'u42', undefined);
+    expect(res._getStatusCode()).toBe(204);
+  });
+
+  it('POST passes label through', async () => {
+    const db = {
+      getUpdateGroup: jest.fn().mockResolvedValue({ id: 'g1', name: 'beta', isDefault: false, createdAt: 't' }),
+      addUserToGroup: jest.fn().mockResolvedValue(undefined),
+    };
+    (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue(db);
+
+    const { req, res } = createMocks({
+      method: 'POST',
+      query: { id: 'g1' },
+      body: { userId: 'u42', label: 'hannes@hopp.bike' },
+    });
+    await membersHandler(req, res);
+
+    expect(db.addUserToGroup).toHaveBeenCalledWith('g1', 'u42', 'hannes@hopp.bike');
     expect(res._getStatusCode()).toBe(204);
   });
 

--- a/__tests__/updateGroupMembers.test.ts
+++ b/__tests__/updateGroupMembers.test.ts
@@ -2,6 +2,7 @@ import { createMocks } from 'node-mocks-http';
 
 import { DatabaseFactory } from '../apiUtils/database/DatabaseFactory';
 import membersHandler from '../pages/api/update-groups/[id]/members';
+import { authedCookies } from './helpers/session';
 
 jest.mock('../apiUtils/database/DatabaseFactory');
 
@@ -16,7 +17,7 @@ describe('Update group members API', () => {
     };
     (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue(db);
 
-    const { req, res } = createMocks({ method: 'GET', query: { id: 'g1' } });
+    const { req, res } = createMocks({ method: 'GET', query: { id: 'g1' }, cookies: authedCookies() });
     await membersHandler(req, res);
 
     expect(res._getStatusCode()).toBe(200);
@@ -34,6 +35,7 @@ describe('Update group members API', () => {
       method: 'POST',
       query: { id: 'g1' },
       body: { userId: 'u42' },
+      cookies: authedCookies(),
     });
     await membersHandler(req, res);
 
@@ -52,6 +54,7 @@ describe('Update group members API', () => {
       method: 'POST',
       query: { id: 'g1' },
       body: { userId: 'u42', label: 'hannes@hopp.bike' },
+      cookies: authedCookies(),
     });
     await membersHandler(req, res);
 
@@ -64,7 +67,7 @@ describe('Update group members API', () => {
       getUpdateGroup: jest.fn().mockResolvedValue({ id: 'g1', name: 'beta', isDefault: false, createdAt: 't' }),
     };
     (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue(db);
-    const { req, res } = createMocks({ method: 'POST', query: { id: 'g1' }, body: {} });
+    const { req, res } = createMocks({ method: 'POST', query: { id: 'g1' }, body: {}, cookies: authedCookies() });
     await membersHandler(req, res);
     expect(res._getStatusCode()).toBe(400);
   });
@@ -74,7 +77,7 @@ describe('Update group members API', () => {
       getUpdateGroup: jest.fn().mockResolvedValue({ id: 'g1', name: 'production', isDefault: true, createdAt: 't' }),
     };
     (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue(db);
-    const { req, res } = createMocks({ method: 'POST', query: { id: 'g1' }, body: { userId: 'u1' } });
+    const { req, res } = createMocks({ method: 'POST', query: { id: 'g1' }, body: { userId: 'u1' }, cookies: authedCookies() });
     await membersHandler(req, res);
     expect(res._getStatusCode()).toBe(400);
   });
@@ -89,6 +92,7 @@ describe('Update group members API', () => {
     const { req, res } = createMocks({
       method: 'DELETE',
       query: { id: 'g1', userId: 'u42' },
+      cookies: authedCookies(),
     });
     await membersHandler(req, res);
 
@@ -99,7 +103,7 @@ describe('Update group members API', () => {
   it('returns 404 if group not found', async () => {
     const db = { getUpdateGroup: jest.fn().mockResolvedValue(null) };
     (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue(db);
-    const { req, res } = createMocks({ method: 'GET', query: { id: 'nope' } });
+    const { req, res } = createMocks({ method: 'GET', query: { id: 'nope' }, cookies: authedCookies() });
     await membersHandler(req, res);
     expect(res._getStatusCode()).toBe(404);
   });

--- a/__tests__/updateGroupMembers.test.ts
+++ b/__tests__/updateGroupMembers.test.ts
@@ -1,0 +1,88 @@
+import { createMocks } from 'node-mocks-http';
+
+import { DatabaseFactory } from '../apiUtils/database/DatabaseFactory';
+import membersHandler from '../pages/api/update-groups/[id]/members';
+
+jest.mock('../apiUtils/database/DatabaseFactory');
+
+describe('Update group members API', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('GET lists members', async () => {
+    const members = [{ updateGroupId: 'g1', userId: 'u1', createdAt: 't' }];
+    const db = {
+      getUpdateGroup: jest.fn().mockResolvedValue({ id: 'g1', name: 'beta', isDefault: false, createdAt: 't' }),
+      listGroupMembers: jest.fn().mockResolvedValue(members),
+    };
+    (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue(db);
+
+    const { req, res } = createMocks({ method: 'GET', query: { id: 'g1' } });
+    await membersHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(JSON.parse(res._getData())).toEqual({ members });
+  });
+
+  it('POST adds a member', async () => {
+    const db = {
+      getUpdateGroup: jest.fn().mockResolvedValue({ id: 'g1', name: 'beta', isDefault: false, createdAt: 't' }),
+      addUserToGroup: jest.fn().mockResolvedValue(undefined),
+    };
+    (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue(db);
+
+    const { req, res } = createMocks({
+      method: 'POST',
+      query: { id: 'g1' },
+      body: { userId: 'u42' },
+    });
+    await membersHandler(req, res);
+
+    expect(db.addUserToGroup).toHaveBeenCalledWith('g1', 'u42');
+    expect(res._getStatusCode()).toBe(204);
+  });
+
+  it('POST rejects missing userId', async () => {
+    const db = {
+      getUpdateGroup: jest.fn().mockResolvedValue({ id: 'g1', name: 'beta', isDefault: false, createdAt: 't' }),
+    };
+    (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue(db);
+    const { req, res } = createMocks({ method: 'POST', query: { id: 'g1' }, body: {} });
+    await membersHandler(req, res);
+    expect(res._getStatusCode()).toBe(400);
+  });
+
+  it('POST rejects when group is the default', async () => {
+    const db = {
+      getUpdateGroup: jest.fn().mockResolvedValue({ id: 'g1', name: 'production', isDefault: true, createdAt: 't' }),
+    };
+    (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue(db);
+    const { req, res } = createMocks({ method: 'POST', query: { id: 'g1' }, body: { userId: 'u1' } });
+    await membersHandler(req, res);
+    expect(res._getStatusCode()).toBe(400);
+  });
+
+  it('DELETE removes a member', async () => {
+    const db = {
+      getUpdateGroup: jest.fn().mockResolvedValue({ id: 'g1', name: 'beta', isDefault: false, createdAt: 't' }),
+      removeUserFromGroup: jest.fn().mockResolvedValue(undefined),
+    };
+    (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue(db);
+
+    const { req, res } = createMocks({
+      method: 'DELETE',
+      query: { id: 'g1', userId: 'u42' },
+    });
+    await membersHandler(req, res);
+
+    expect(db.removeUserFromGroup).toHaveBeenCalledWith('g1', 'u42');
+    expect(res._getStatusCode()).toBe(204);
+  });
+
+  it('returns 404 if group not found', async () => {
+    const db = { getUpdateGroup: jest.fn().mockResolvedValue(null) };
+    (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue(db);
+    const { req, res } = createMocks({ method: 'GET', query: { id: 'nope' } });
+    await membersHandler(req, res);
+    expect(res._getStatusCode()).toBe(404);
+  });
+});

--- a/__tests__/updateGroups.test.ts
+++ b/__tests__/updateGroups.test.ts
@@ -1,0 +1,81 @@
+import { createMocks } from 'node-mocks-http';
+
+import { DatabaseFactory } from '../apiUtils/database/DatabaseFactory';
+import indexHandler from '../pages/api/update-groups/index';
+import idHandler from '../pages/api/update-groups/[id]';
+
+jest.mock('../apiUtils/database/DatabaseFactory');
+
+describe('Update groups API', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('GET /api/update-groups returns the list', async () => {
+    const groups = [
+      { id: 'g1', name: 'production', isDefault: true, createdAt: 't' },
+      { id: 'g2', name: 'beta', isDefault: false, createdAt: 't' },
+    ];
+    const db = { listUpdateGroups: jest.fn().mockResolvedValue(groups) };
+    (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue(db);
+
+    const { req, res } = createMocks({ method: 'GET' });
+    await indexHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(JSON.parse(res._getData())).toEqual({ groups });
+  });
+
+  it('POST /api/update-groups creates a group', async () => {
+    const created = { id: 'g3', name: 'alpha', isDefault: false, createdAt: 't' };
+    const db = { createUpdateGroup: jest.fn().mockResolvedValue(created) };
+    (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue(db);
+
+    const { req, res } = createMocks({
+      method: 'POST',
+      body: { name: 'alpha' },
+    });
+    await indexHandler(req, res);
+
+    expect(db.createUpdateGroup).toHaveBeenCalledWith('alpha');
+    expect(res._getStatusCode()).toBe(201);
+    expect(JSON.parse(res._getData())).toEqual({ group: created });
+  });
+
+  it('POST /api/update-groups rejects missing name', async () => {
+    (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue({});
+    const { req, res } = createMocks({ method: 'POST', body: {} });
+    await indexHandler(req, res);
+    expect(res._getStatusCode()).toBe(400);
+  });
+
+  it('DELETE /api/update-groups/:id refuses if group is default', async () => {
+    const db = {
+      getUpdateGroup: jest.fn().mockResolvedValue({
+        id: 'g1', name: 'production', isDefault: true, createdAt: 't',
+      }),
+      deleteUpdateGroup: jest.fn(),
+    };
+    (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue(db);
+
+    const { req, res } = createMocks({ method: 'DELETE', query: { id: 'g1' } });
+    await idHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(db.deleteUpdateGroup).not.toHaveBeenCalled();
+  });
+
+  it('DELETE /api/update-groups/:id deletes a non-default group', async () => {
+    const db = {
+      getUpdateGroup: jest.fn().mockResolvedValue({
+        id: 'g2', name: 'beta', isDefault: false, createdAt: 't',
+      }),
+      deleteUpdateGroup: jest.fn().mockResolvedValue(undefined),
+    };
+    (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue(db);
+
+    const { req, res } = createMocks({ method: 'DELETE', query: { id: 'g2' } });
+    await idHandler(req, res);
+
+    expect(db.deleteUpdateGroup).toHaveBeenCalledWith('g2');
+    expect(res._getStatusCode()).toBe(204);
+  });
+});

--- a/__tests__/updateGroups.test.ts
+++ b/__tests__/updateGroups.test.ts
@@ -3,6 +3,7 @@ import { createMocks } from 'node-mocks-http';
 import { DatabaseFactory } from '../apiUtils/database/DatabaseFactory';
 import indexHandler from '../pages/api/update-groups/index';
 import idHandler from '../pages/api/update-groups/[id]';
+import { authedCookies } from './helpers/session';
 
 jest.mock('../apiUtils/database/DatabaseFactory');
 
@@ -17,7 +18,7 @@ describe('Update groups API', () => {
     const db = { listUpdateGroups: jest.fn().mockResolvedValue(groups) };
     (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue(db);
 
-    const { req, res } = createMocks({ method: 'GET' });
+    const { req, res } = createMocks({ method: 'GET', cookies: authedCookies() });
     await indexHandler(req, res);
 
     expect(res._getStatusCode()).toBe(200);
@@ -32,6 +33,7 @@ describe('Update groups API', () => {
     const { req, res } = createMocks({
       method: 'POST',
       body: { name: 'alpha' },
+      cookies: authedCookies(),
     });
     await indexHandler(req, res);
 
@@ -42,7 +44,7 @@ describe('Update groups API', () => {
 
   it('POST /api/update-groups rejects missing name', async () => {
     (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue({});
-    const { req, res } = createMocks({ method: 'POST', body: {} });
+    const { req, res } = createMocks({ method: 'POST', body: {}, cookies: authedCookies() });
     await indexHandler(req, res);
     expect(res._getStatusCode()).toBe(400);
   });
@@ -56,7 +58,7 @@ describe('Update groups API', () => {
     };
     (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue(db);
 
-    const { req, res } = createMocks({ method: 'DELETE', query: { id: 'g1' } });
+    const { req, res } = createMocks({ method: 'DELETE', query: { id: 'g1' }, cookies: authedCookies() });
     await idHandler(req, res);
 
     expect(res._getStatusCode()).toBe(400);
@@ -72,10 +74,16 @@ describe('Update groups API', () => {
     };
     (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue(db);
 
-    const { req, res } = createMocks({ method: 'DELETE', query: { id: 'g2' } });
+    const { req, res } = createMocks({ method: 'DELETE', query: { id: 'g2' }, cookies: authedCookies() });
     await idHandler(req, res);
 
     expect(db.deleteUpdateGroup).toHaveBeenCalledWith('g2');
     expect(res._getStatusCode()).toBe(204);
+  });
+
+  it('returns 401 without a valid session cookie', async () => {
+    const { req, res } = createMocks({ method: 'GET' });
+    await indexHandler(req, res);
+    expect(res._getStatusCode()).toBe(401);
   });
 });

--- a/__tests__/upload.test.ts
+++ b/__tests__/upload.test.ts
@@ -68,6 +68,12 @@ describe('Upload API', () => {
       uploadFile: jest.fn().mockResolvedValue('updates/1.0.0/timestamp.zip'),
     };
     const mockDatabase = {
+      getDefaultUpdateGroup: jest.fn().mockResolvedValue({
+        id: 'g-prod',
+        name: 'production',
+        isDefault: true,
+        createdAt: 't',
+      }),
       createRelease: jest.fn().mockResolvedValue(true),
     };
     (StorageFactory.getStorage as jest.Mock).mockReturnValue(mockStorage);
@@ -83,17 +89,126 @@ describe('Upload API', () => {
 
     // Verify all mocks were called correctly
     expect(mockStorage.uploadFile).toHaveBeenCalled();
-    expect(mockDatabase.createRelease).toHaveBeenCalledWith({
+    expect(mockDatabase.createRelease).toHaveBeenCalledWith(expect.objectContaining({
       path: 'updates/1.0.0/timestamp.zip',
       runtimeVersion: '1.0.0',
       timestamp: expect.any(String),
       commitHash: 'abc123',
       commitMessage: 'Test commit message',
       updateId: mockUpdateId,
-    });
+      updateGroupId: 'g-prod',
+    }));
     expect(ZipHelper.getFileFromZip).toHaveBeenCalledWith(mockZipFolder, 'metadata.json');
     expect(HashHelper.createHash).toHaveBeenCalledWith(mockMetadataContent, 'sha256', 'hex');
     expect(HashHelper.convertSHA256HashToUUID).toHaveBeenCalledWith(mockHash);
+  });
+
+  it('uses the named update group when provided', async () => {
+    const mockForm = {
+      parse: jest.fn().mockResolvedValue([
+        {
+          uploadKey: [process.env.UPLOAD_KEY],
+          runtimeVersion: ['1.0.0'],
+          commitHash: ['abc123'],
+          commitMessage: ['m'],
+          updateGroup: ['beta'],
+        },
+        { file: [{ filepath: 'test.zip' }] },
+      ]),
+    };
+    (formidable as unknown as jest.Mock).mockReturnValue(mockForm);
+
+    jest.spyOn(fs, 'readFileSync').mockReturnValue(Buffer.from('x'));
+    (AdmZip as unknown as jest.Mock).mockImplementation(() => ({} as AdmZip));
+    (ZipHelper.getFileFromZip as jest.Mock).mockResolvedValue(Buffer.from('{}'));
+    (HashHelper.createHash as jest.Mock).mockReturnValue('hash');
+    (HashHelper.convertSHA256HashToUUID as jest.Mock).mockReturnValue('uid');
+
+    const mockStorage = { uploadFile: jest.fn().mockResolvedValue('updates/1.0.0/t.zip') };
+    const createRelease = jest.fn().mockResolvedValue({});
+    const mockDatabase = {
+      getUpdateGroupByName: jest.fn().mockResolvedValue({
+        id: 'g-beta', name: 'beta', isDefault: false, createdAt: 't',
+      }),
+      getDefaultUpdateGroup: jest.fn(),
+      createRelease,
+    };
+    (StorageFactory.getStorage as jest.Mock).mockReturnValue(mockStorage);
+    (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue(mockDatabase);
+
+    const { req, res } = createMocks({ method: 'POST' });
+    await uploadHandler(req, res);
+
+    expect(mockDatabase.getUpdateGroupByName).toHaveBeenCalledWith('beta');
+    expect(mockDatabase.getDefaultUpdateGroup).not.toHaveBeenCalled();
+    expect(createRelease).toHaveBeenCalledWith(expect.objectContaining({ updateGroupId: 'g-beta' }));
+    expect(res._getStatusCode()).toBe(200);
+  });
+
+  it('falls back to the default group when updateGroup is omitted', async () => {
+    const mockForm = {
+      parse: jest.fn().mockResolvedValue([
+        {
+          uploadKey: [process.env.UPLOAD_KEY],
+          runtimeVersion: ['1.0.0'],
+          commitHash: ['abc'],
+          commitMessage: ['m'],
+        },
+        { file: [{ filepath: 'test.zip' }] },
+      ]),
+    };
+    (formidable as unknown as jest.Mock).mockReturnValue(mockForm);
+
+    jest.spyOn(fs, 'readFileSync').mockReturnValue(Buffer.from('x'));
+    (AdmZip as unknown as jest.Mock).mockImplementation(() => ({} as AdmZip));
+    (ZipHelper.getFileFromZip as jest.Mock).mockResolvedValue(Buffer.from('{}'));
+    (HashHelper.createHash as jest.Mock).mockReturnValue('hash');
+    (HashHelper.convertSHA256HashToUUID as jest.Mock).mockReturnValue('uid');
+
+    const createRelease = jest.fn().mockResolvedValue({});
+    const mockDatabase = {
+      getUpdateGroupByName: jest.fn(),
+      getDefaultUpdateGroup: jest.fn().mockResolvedValue({
+        id: 'g-prod', name: 'production', isDefault: true, createdAt: 't',
+      }),
+      createRelease,
+    };
+    (StorageFactory.getStorage as jest.Mock).mockReturnValue({
+      uploadFile: jest.fn().mockResolvedValue('updates/1.0.0/t.zip'),
+    });
+    (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue(mockDatabase);
+
+    const { req, res } = createMocks({ method: 'POST' });
+    await uploadHandler(req, res);
+
+    expect(mockDatabase.getDefaultUpdateGroup).toHaveBeenCalled();
+    expect(createRelease).toHaveBeenCalledWith(expect.objectContaining({ updateGroupId: 'g-prod' }));
+  });
+
+  it('rejects with 400 when updateGroup name is unknown', async () => {
+    const mockForm = {
+      parse: jest.fn().mockResolvedValue([
+        {
+          uploadKey: [process.env.UPLOAD_KEY],
+          runtimeVersion: ['1.0.0'],
+          commitHash: ['abc'],
+          commitMessage: ['m'],
+          updateGroup: ['nonexistent'],
+        },
+        { file: [{ filepath: 'test.zip' }] },
+      ]),
+    };
+    (formidable as unknown as jest.Mock).mockReturnValue(mockForm);
+
+    const mockDatabase = {
+      getUpdateGroupByName: jest.fn().mockResolvedValue(null),
+    };
+    (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue(mockDatabase);
+
+    const { req, res } = createMocks({ method: 'POST' });
+    await uploadHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
   });
 
   it('should return 400 for missing required fields', async () => {

--- a/apiUtils/auth/session.ts
+++ b/apiUtils/auth/session.ts
@@ -1,0 +1,73 @@
+import { createHmac, timingSafeEqual } from 'crypto';
+import { NextApiRequest, NextApiResponse } from 'next';
+
+export const SESSION_COOKIE = 'xavia-ota-session';
+const MAX_AGE_SECONDS = 60 * 60 * 24 * 7; // 7 days
+
+function getSecret(): Buffer {
+  const secret = process.env.SESSION_SECRET;
+  if (!secret) throw new Error('SESSION_SECRET is not configured');
+  return Buffer.from(secret, 'utf8');
+}
+
+function sign(payload: string): string {
+  return createHmac('sha256', getSecret()).update(payload).digest('hex');
+}
+
+export function generateSessionValue(): string {
+  const payload = JSON.stringify({ iat: Date.now() });
+  const b64 = Buffer.from(payload, 'utf8').toString('base64url');
+  return `${b64}.${sign(b64)}`;
+}
+
+function cookieAttrs(): string {
+  const isProd = process.env.NODE_ENV === 'production';
+  return `HttpOnly; SameSite=Strict; Path=/${isProd ? '; Secure' : ''}`;
+}
+
+export function issueSessionCookie(res: NextApiResponse): void {
+  const value = generateSessionValue();
+  res.setHeader(
+    'Set-Cookie',
+    `${SESSION_COOKIE}=${value}; ${cookieAttrs()}; Max-Age=${MAX_AGE_SECONDS}`
+  );
+}
+
+export function clearSessionCookie(res: NextApiResponse): void {
+  res.setHeader('Set-Cookie', `${SESSION_COOKIE}=; ${cookieAttrs()}; Max-Age=0`);
+}
+
+export function verifySession(req: NextApiRequest): boolean {
+  const cookie = req.cookies?.[SESSION_COOKIE];
+  if (!cookie) return false;
+  const [b64, sig] = cookie.split('.');
+  if (!b64 || !sig) return false;
+
+  let expected: string;
+  try {
+    expected = sign(b64);
+  } catch {
+    return false;
+  }
+  if (sig.length !== expected.length) return false;
+  try {
+    if (!timingSafeEqual(Buffer.from(sig, 'hex'), Buffer.from(expected, 'hex'))) return false;
+  } catch {
+    return false;
+  }
+
+  try {
+    const payload = JSON.parse(Buffer.from(b64, 'base64url').toString('utf8'));
+    if (typeof payload.iat !== 'number') return false;
+    if (Date.now() - payload.iat > MAX_AGE_SECONDS * 1000) return false;
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function requireSession(req: NextApiRequest, res: NextApiResponse): boolean {
+  if (verifySession(req)) return true;
+  res.status(401).json({ error: 'Authentication required' });
+  return false;
+}

--- a/apiUtils/database/DatabaseFactory.ts
+++ b/apiUtils/database/DatabaseFactory.ts
@@ -5,6 +5,8 @@ import { SupabaseDatabase } from './SupabaseDatabase';
 export enum Tables {
   RELEASES = 'releases',
   RELEASES_TRACKING = 'releases_tracking',
+  UPDATE_GROUPS = 'update_groups',
+  UPDATE_GROUP_MEMBERS = 'update_group_members',
 }
 
 export class DatabaseFactory {

--- a/apiUtils/database/DatabaseInterface.ts
+++ b/apiUtils/database/DatabaseInterface.ts
@@ -59,8 +59,5 @@ export interface DatabaseInterface {
   removeUserFromGroup(updateGroupId: string, userId: string): Promise<void>;
 
   // Resolver
-  getLatestReleaseForUser(
-    runtimeVersion: string,
-    userId: string | null
-  ): Promise<Release | null>;
+  getLatestReleaseForUser(runtimeVersion: string, userId: string | null): Promise<Release | null>;
 }

--- a/apiUtils/database/DatabaseInterface.ts
+++ b/apiUtils/database/DatabaseInterface.ts
@@ -32,6 +32,7 @@ export interface UpdateGroup {
 export interface UpdateGroupMember {
   updateGroupId: string;
   userId: string;
+  label?: string;
   createdAt: string;
 }
 
@@ -55,7 +56,7 @@ export interface DatabaseInterface {
 
   // Membership
   listGroupMembers(updateGroupId: string): Promise<UpdateGroupMember[]>;
-  addUserToGroup(updateGroupId: string, userId: string): Promise<void>;
+  addUserToGroup(updateGroupId: string, userId: string, label?: string): Promise<void>;
   removeUserFromGroup(updateGroupId: string, userId: string): Promise<void>;
 
   // Resolver

--- a/apiUtils/database/DatabaseInterface.ts
+++ b/apiUtils/database/DatabaseInterface.ts
@@ -6,6 +6,8 @@ export interface Release {
   commitHash: string;
   commitMessage: string;
   updateId?: string;
+  updateGroupId: string;
+  updateGroupName?: string;
 }
 
 export interface Tracking {
@@ -20,8 +22,21 @@ export interface TrackingMetrics {
   count: number;
 }
 
+export interface UpdateGroup {
+  id: string;
+  name: string;
+  isDefault: boolean;
+  createdAt: string;
+}
+
+export interface UpdateGroupMember {
+  updateGroupId: string;
+  userId: string;
+  createdAt: string;
+}
+
 export interface DatabaseInterface {
-  createRelease(release: Omit<Release, 'id'>): Promise<Release>;
+  createRelease(release: Omit<Release, 'id' | 'updateGroupName'>): Promise<Release>;
   getRelease(id: string): Promise<Release | null>;
   getReleaseByPath(path: string): Promise<Release | null>;
   listReleases(): Promise<Release[]>;
@@ -29,4 +44,23 @@ export interface DatabaseInterface {
   getReleaseTrackingMetrics(releaseId: string): Promise<TrackingMetrics[]>;
   getReleaseTrackingMetricsForAllReleases(): Promise<TrackingMetrics[]>;
   getLatestReleaseRecordForRuntimeVersion(runtimeVersion: string): Promise<Release | null>;
+
+  // Update groups
+  listUpdateGroups(): Promise<UpdateGroup[]>;
+  getUpdateGroup(id: string): Promise<UpdateGroup | null>;
+  getUpdateGroupByName(name: string): Promise<UpdateGroup | null>;
+  getDefaultUpdateGroup(): Promise<UpdateGroup>;
+  createUpdateGroup(name: string): Promise<UpdateGroup>;
+  deleteUpdateGroup(id: string): Promise<void>;
+
+  // Membership
+  listGroupMembers(updateGroupId: string): Promise<UpdateGroupMember[]>;
+  addUserToGroup(updateGroupId: string, userId: string): Promise<void>;
+  removeUserFromGroup(updateGroupId: string, userId: string): Promise<void>;
+
+  // Resolver
+  getLatestReleaseForUser(
+    runtimeVersion: string,
+    userId: string | null
+  ): Promise<Release | null>;
 }

--- a/apiUtils/database/LocalDatabase.ts
+++ b/apiUtils/database/LocalDatabase.ts
@@ -211,35 +211,24 @@ export class PostgresDatabase implements DatabaseInterface {
     runtimeVersion: string,
     userId: string | null
   ): Promise<Release | null> {
-    const baseSelect = `
+    // Reachable releases for this user: anything in the default group, plus anything
+    // in a non-default group the user is a member of. The LEFT JOIN to memberships
+    // hits the (update_group_id, user_id) primary key index. Non-default releases
+    // sort before the default fallback (booleans order FALSE < TRUE in postgres).
+    const query = `
       SELECT r.id, r.runtime_version as "runtimeVersion", r.path, r.timestamp,
              r.commit_hash as "commitHash", r.commit_message as "commitMessage",
              r.update_id as "updateId", r.update_group_id as "updateGroupId"
       FROM ${Tables.RELEASES} r
-    `;
-
-    if (userId) {
-      const groupQuery = `
-        ${baseSelect}
-        WHERE r.runtime_version = $1
-          AND r.update_group_id IN (
-            SELECT update_group_id FROM ${Tables.UPDATE_GROUP_MEMBERS} WHERE user_id = $2
-          )
-        ORDER BY r.timestamp DESC
-        LIMIT 1
-      `;
-      const groupResult = await this.pool.query(groupQuery, [runtimeVersion, userId]);
-      if (groupResult.rows[0]) return groupResult.rows[0];
-    }
-
-    const defaultQuery = `
-      ${baseSelect}
       JOIN ${Tables.UPDATE_GROUPS} g ON r.update_group_id = g.id
-      WHERE r.runtime_version = $1 AND g.is_default = true
-      ORDER BY r.timestamp DESC
+      LEFT JOIN ${Tables.UPDATE_GROUP_MEMBERS} m
+        ON m.update_group_id = r.update_group_id AND m.user_id = $2
+      WHERE r.runtime_version = $1
+        AND (g.is_default = true OR m.user_id IS NOT NULL)
+      ORDER BY g.is_default ASC, r.timestamp DESC
       LIMIT 1
     `;
-    const defaultResult = await this.pool.query(defaultQuery, [runtimeVersion]);
-    return defaultResult.rows[0] || null;
+    const { rows } = await this.pool.query(query, [runtimeVersion, userId]);
+    return rows[0] || null;
   }
 }

--- a/apiUtils/database/LocalDatabase.ts
+++ b/apiUtils/database/LocalDatabase.ts
@@ -182,7 +182,7 @@ export class PostgresDatabase implements DatabaseInterface {
 
   async listGroupMembers(updateGroupId: string): Promise<UpdateGroupMember[]> {
     const { rows } = await this.pool.query(
-      `SELECT update_group_id as "updateGroupId", user_id as "userId", created_at as "createdAt"
+      `SELECT update_group_id as "updateGroupId", user_id as "userId", label, created_at as "createdAt"
        FROM ${Tables.UPDATE_GROUP_MEMBERS} WHERE update_group_id = $1
        ORDER BY created_at DESC`,
       [updateGroupId]
@@ -190,12 +190,12 @@ export class PostgresDatabase implements DatabaseInterface {
     return rows;
   }
 
-  async addUserToGroup(updateGroupId: string, userId: string): Promise<void> {
+  async addUserToGroup(updateGroupId: string, userId: string, label?: string): Promise<void> {
     await this.pool.query(
-      `INSERT INTO ${Tables.UPDATE_GROUP_MEMBERS} (update_group_id, user_id)
-       VALUES ($1, $2)
-       ON CONFLICT DO NOTHING`,
-      [updateGroupId, userId]
+      `INSERT INTO ${Tables.UPDATE_GROUP_MEMBERS} (update_group_id, user_id, label)
+       VALUES ($1, $2, $3)
+       ON CONFLICT (update_group_id, user_id) DO UPDATE SET label = EXCLUDED.label`,
+      [updateGroupId, userId, label ?? null]
     );
   }
 

--- a/apiUtils/database/LocalDatabase.ts
+++ b/apiUtils/database/LocalDatabase.ts
@@ -1,6 +1,13 @@
 import { Pool } from 'pg';
 
-import { DatabaseInterface, Release, Tracking, TrackingMetrics } from './DatabaseInterface';
+import {
+  DatabaseInterface,
+  Release,
+  Tracking,
+  TrackingMetrics,
+  UpdateGroup,
+  UpdateGroupMember,
+} from './DatabaseInterface';
 import { Tables } from './DatabaseFactory';
 
 export class PostgresDatabase implements DatabaseInterface {
@@ -73,13 +80,15 @@ export class PostgresDatabase implements DatabaseInterface {
     }));
   }
 
-  async createRelease(release: Omit<Release, 'id'>): Promise<Release> {
+  async createRelease(release: Omit<Release, 'id' | 'updateGroupName'>): Promise<Release> {
     const query = `
-      INSERT INTO ${Tables.RELEASES} (runtime_version, path, timestamp, commit_hash, commit_message, update_id)
-      VALUES ($1, $2, $3, $4, $5, $6)
-      RETURNING id, runtime_version as "runtimeVersion", path, timestamp, commit_hash as "commitHash", update_id as "updateId"
+      INSERT INTO ${Tables.RELEASES}
+        (runtime_version, path, timestamp, commit_hash, commit_message, update_id, update_group_id)
+      VALUES ($1, $2, $3, $4, $5, $6, $7)
+      RETURNING id, runtime_version as "runtimeVersion", path, timestamp,
+                commit_hash as "commitHash", commit_message as "commitMessage",
+                update_id as "updateId", update_group_id as "updateGroupId"
     `;
-
     const values = [
       release.runtimeVersion,
       release.path,
@@ -87,6 +96,7 @@ export class PostgresDatabase implements DatabaseInterface {
       release.commitHash,
       release.commitMessage,
       release.updateId,
+      release.updateGroupId,
     ];
     const { rows } = await this.pool.query(query, values);
     return rows[0];
@@ -104,12 +114,128 @@ export class PostgresDatabase implements DatabaseInterface {
 
   async listReleases(): Promise<Release[]> {
     const query = `
-      SELECT id, runtime_version as "runtimeVersion", path, timestamp, commit_hash as "commitHash", commit_message as "commitMessage"
-      FROM ${Tables.RELEASES}
-      ORDER BY timestamp DESC
+      SELECT r.id, r.runtime_version as "runtimeVersion", r.path, r.timestamp,
+             r.commit_hash as "commitHash", r.commit_message as "commitMessage",
+             r.update_id as "updateId", r.update_group_id as "updateGroupId",
+             g.name as "updateGroupName"
+      FROM ${Tables.RELEASES} r
+      LEFT JOIN ${Tables.UPDATE_GROUPS} g ON r.update_group_id = g.id
+      ORDER BY r.timestamp DESC
     `;
-
     const { rows } = await this.pool.query(query);
     return rows;
+  }
+
+  async listUpdateGroups(): Promise<UpdateGroup[]> {
+    const { rows } = await this.pool.query(`
+      SELECT id, name, is_default as "isDefault", created_at as "createdAt"
+      FROM ${Tables.UPDATE_GROUPS}
+      ORDER BY is_default DESC, name ASC
+    `);
+    return rows;
+  }
+
+  async getUpdateGroup(id: string): Promise<UpdateGroup | null> {
+    const { rows } = await this.pool.query(
+      `SELECT id, name, is_default as "isDefault", created_at as "createdAt"
+       FROM ${Tables.UPDATE_GROUPS} WHERE id = $1`,
+      [id]
+    );
+    return rows[0] || null;
+  }
+
+  async getUpdateGroupByName(name: string): Promise<UpdateGroup | null> {
+    const { rows } = await this.pool.query(
+      `SELECT id, name, is_default as "isDefault", created_at as "createdAt"
+       FROM ${Tables.UPDATE_GROUPS} WHERE name = $1`,
+      [name]
+    );
+    return rows[0] || null;
+  }
+
+  async getDefaultUpdateGroup(): Promise<UpdateGroup> {
+    const { rows } = await this.pool.query(
+      `SELECT id, name, is_default as "isDefault", created_at as "createdAt"
+       FROM ${Tables.UPDATE_GROUPS} WHERE is_default = true LIMIT 1`
+    );
+    if (!rows[0]) throw new Error('No default update group configured');
+    return rows[0];
+  }
+
+  async createUpdateGroup(name: string): Promise<UpdateGroup> {
+    const { rows } = await this.pool.query(
+      `INSERT INTO ${Tables.UPDATE_GROUPS} (name)
+       VALUES ($1)
+       RETURNING id, name, is_default as "isDefault", created_at as "createdAt"`,
+      [name]
+    );
+    return rows[0];
+  }
+
+  async deleteUpdateGroup(id: string): Promise<void> {
+    await this.pool.query(`DELETE FROM ${Tables.UPDATE_GROUPS} WHERE id = $1`, [id]);
+  }
+
+  async listGroupMembers(updateGroupId: string): Promise<UpdateGroupMember[]> {
+    const { rows } = await this.pool.query(
+      `SELECT update_group_id as "updateGroupId", user_id as "userId", created_at as "createdAt"
+       FROM ${Tables.UPDATE_GROUP_MEMBERS} WHERE update_group_id = $1
+       ORDER BY created_at DESC`,
+      [updateGroupId]
+    );
+    return rows;
+  }
+
+  async addUserToGroup(updateGroupId: string, userId: string): Promise<void> {
+    await this.pool.query(
+      `INSERT INTO ${Tables.UPDATE_GROUP_MEMBERS} (update_group_id, user_id)
+       VALUES ($1, $2)
+       ON CONFLICT DO NOTHING`,
+      [updateGroupId, userId]
+    );
+  }
+
+  async removeUserFromGroup(updateGroupId: string, userId: string): Promise<void> {
+    await this.pool.query(
+      `DELETE FROM ${Tables.UPDATE_GROUP_MEMBERS}
+       WHERE update_group_id = $1 AND user_id = $2`,
+      [updateGroupId, userId]
+    );
+  }
+
+  async getLatestReleaseForUser(
+    runtimeVersion: string,
+    userId: string | null
+  ): Promise<Release | null> {
+    const baseSelect = `
+      SELECT r.id, r.runtime_version as "runtimeVersion", r.path, r.timestamp,
+             r.commit_hash as "commitHash", r.commit_message as "commitMessage",
+             r.update_id as "updateId", r.update_group_id as "updateGroupId"
+      FROM ${Tables.RELEASES} r
+    `;
+
+    if (userId) {
+      const groupQuery = `
+        ${baseSelect}
+        WHERE r.runtime_version = $1
+          AND r.update_group_id IN (
+            SELECT update_group_id FROM ${Tables.UPDATE_GROUP_MEMBERS} WHERE user_id = $2
+          )
+        ORDER BY r.timestamp DESC
+        LIMIT 1
+      `;
+      const groupResult = await this.pool.query(groupQuery, [runtimeVersion, userId]);
+      if (groupResult.rows[0]) return groupResult.rows[0];
+    }
+
+    const defaultQuery = `
+      ${baseSelect}
+      JOIN ${Tables.UPDATE_GROUPS} g ON r.update_group_id = g.id
+      WHERE r.runtime_version = $1 AND g.is_default = true
+      ORDER BY r.timestamp DESC
+      LIMIT 1
+    `;
+    const defaultResult = await this.pool.query(defaultQuery, [runtimeVersion]);
+    return defaultResult.rows[0] || null;
   }
 }

--- a/apiUtils/database/LocalDatabase.ts
+++ b/apiUtils/database/LocalDatabase.ts
@@ -35,7 +35,9 @@ export class PostgresDatabase implements DatabaseInterface {
   }
   async getReleaseByPath(path: string): Promise<Release | null> {
     const query = `
-      SELECT id, runtime_version as "runtimeVersion", path, timestamp, commit_hash as "commitHash"
+      SELECT id, runtime_version as "runtimeVersion", path, timestamp,
+             commit_hash as "commitHash", commit_message as "commitMessage",
+             update_id as "updateId", update_group_id as "updateGroupId"
       FROM ${Tables.RELEASES} WHERE path = $1
     `;
     const { rows } = await this.pool.query(query, [path]);
@@ -104,7 +106,9 @@ export class PostgresDatabase implements DatabaseInterface {
 
   async getRelease(id: string): Promise<Release | null> {
     const query = `
-      SELECT id, runtime_version as "runtimeVersion", path, timestamp, commit_hash as "commitHash"
+      SELECT id, runtime_version as "runtimeVersion", path, timestamp,
+             commit_hash as "commitHash", commit_message as "commitMessage",
+             update_id as "updateId", update_group_id as "updateGroupId"
       FROM ${Tables.RELEASES} WHERE id = $1
     `;
 

--- a/apiUtils/database/SupabaseDatabase.ts
+++ b/apiUtils/database/SupabaseDatabase.ts
@@ -254,10 +254,7 @@ export class SupabaseDatabase implements DatabaseInterface {
   }
 
   async deleteUpdateGroup(id: string): Promise<void> {
-    const { error } = await this.supabase
-      .from(Tables.UPDATE_GROUPS)
-      .delete()
-      .eq('id', id);
+    const { error } = await this.supabase.from(Tables.UPDATE_GROUPS).delete().eq('id', id);
     if (error) throw new Error(error.message);
   }
 
@@ -305,7 +302,9 @@ export class SupabaseDatabase implements DatabaseInterface {
         .eq('user_id', userId);
       if (memErr) throw new Error(memErr.message);
 
-      const groupIds = (memberships ?? []).map((m: { update_group_id: string }) => m.update_group_id);
+      const groupIds = (memberships ?? []).map(
+        (m: { update_group_id: string }) => m.update_group_id
+      );
       if (groupIds.length > 0) {
         const { data, error } = await this.supabase
           .from(Tables.RELEASES)

--- a/apiUtils/database/SupabaseDatabase.ts
+++ b/apiUtils/database/SupabaseDatabase.ts
@@ -268,16 +268,17 @@ export class SupabaseDatabase implements DatabaseInterface {
     return (data ?? []).map((m) => ({
       updateGroupId: m.update_group_id,
       userId: m.user_id,
+      label: m.label ?? undefined,
       createdAt: m.created_at,
     }));
   }
 
-  async addUserToGroup(updateGroupId: string, userId: string): Promise<void> {
+  async addUserToGroup(updateGroupId: string, userId: string, label?: string): Promise<void> {
     const { error } = await this.supabase
       .from(Tables.UPDATE_GROUP_MEMBERS)
       .upsert(
-        { update_group_id: updateGroupId, user_id: userId },
-        { onConflict: 'update_group_id,user_id', ignoreDuplicates: true }
+        { update_group_id: updateGroupId, user_id: userId, label: label ?? null },
+        { onConflict: 'update_group_id,user_id' }
       );
     if (error) throw new Error(error.message);
   }

--- a/apiUtils/database/SupabaseDatabase.ts
+++ b/apiUtils/database/SupabaseDatabase.ts
@@ -1,6 +1,13 @@
 import { createClient } from '@supabase/supabase-js';
 
-import { DatabaseInterface, Release, Tracking, TrackingMetrics } from './DatabaseInterface';
+import {
+  DatabaseInterface,
+  Release,
+  Tracking,
+  TrackingMetrics,
+  UpdateGroup,
+  UpdateGroupMember,
+} from './DatabaseInterface';
 import { Tables } from './DatabaseFactory';
 
 export class SupabaseDatabase implements DatabaseInterface {
@@ -37,6 +44,7 @@ export class SupabaseDatabase implements DatabaseInterface {
         commitHash: data.commit_hash,
         commitMessage: data.commit_message,
         updateId: data.update_id,
+        updateGroupId: data.update_group_id,
       };
     }
 
@@ -52,7 +60,17 @@ export class SupabaseDatabase implements DatabaseInterface {
 
     if (error) throw new Error(error.message);
 
-    return data || null;
+    if (!data) return null;
+    return {
+      id: data.id,
+      path: data.path,
+      runtimeVersion: data.runtime_version,
+      timestamp: data.timestamp,
+      commitHash: data.commit_hash,
+      commitMessage: data.commit_message,
+      updateId: data.update_id,
+      updateGroupId: data.update_group_id,
+    };
   }
 
   async getReleaseTrackingMetricsForAllReleases(): Promise<TrackingMetrics[]> {
@@ -119,7 +137,7 @@ export class SupabaseDatabase implements DatabaseInterface {
     ];
   }
 
-  async createRelease(release: Omit<Release, 'id'>): Promise<Release> {
+  async createRelease(release: Omit<Release, 'id' | 'updateGroupName'>): Promise<Release> {
     const { data, error } = await this.supabase
       .from(Tables.RELEASES)
       .insert({
@@ -129,12 +147,12 @@ export class SupabaseDatabase implements DatabaseInterface {
         commit_hash: release.commitHash,
         commit_message: release.commitMessage,
         update_id: release.updateId,
+        update_group_id: release.updateGroupId,
       })
       .select()
       .single();
-
     if (error) throw error;
-    return data;
+    return this.mapReleaseRow(data);
   }
 
   async getRelease(id: string): Promise<Release | null> {
@@ -153,24 +171,178 @@ export class SupabaseDatabase implements DatabaseInterface {
       timestamp: data.timestamp,
       commitHash: data.commit_hash,
       commitMessage: data.commit_message,
+      updateId: data.update_id,
+      updateGroupId: data.update_group_id,
     };
   }
 
   async listReleases(): Promise<Release[]> {
     const { data, error } = await this.supabase
       .from(Tables.RELEASES)
-      .select()
+      .select(`*, ${Tables.UPDATE_GROUPS}(name)`)
       .order('timestamp', { ascending: false });
-
     if (error) throw error;
-    return data.map((release) => ({
-      id: release.id,
-      path: release.path,
-      runtimeVersion: release.runtime_version,
-      timestamp: release.timestamp,
-      size: release.size,
-      commitHash: release.commit_hash,
-      commitMessage: release.commit_message,
+    return (data ?? []).map((r) => ({
+      id: r.id,
+      path: r.path,
+      runtimeVersion: r.runtime_version,
+      timestamp: r.timestamp,
+      commitHash: r.commit_hash,
+      commitMessage: r.commit_message,
+      updateId: r.update_id,
+      updateGroupId: r.update_group_id,
+      updateGroupName: r[Tables.UPDATE_GROUPS]?.name,
     }));
+  }
+
+  async listUpdateGroups(): Promise<UpdateGroup[]> {
+    const { data, error } = await this.supabase
+      .from(Tables.UPDATE_GROUPS)
+      .select()
+      .order('is_default', { ascending: false })
+      .order('name', { ascending: true });
+    if (error) throw new Error(error.message);
+    return (data ?? []).map((g) => ({
+      id: g.id,
+      name: g.name,
+      isDefault: g.is_default,
+      createdAt: g.created_at,
+    }));
+  }
+
+  async getUpdateGroup(id: string): Promise<UpdateGroup | null> {
+    const { data, error } = await this.supabase
+      .from(Tables.UPDATE_GROUPS)
+      .select()
+      .eq('id', id)
+      .maybeSingle();
+    if (error) throw new Error(error.message);
+    if (!data) return null;
+    return { id: data.id, name: data.name, isDefault: data.is_default, createdAt: data.created_at };
+  }
+
+  async getUpdateGroupByName(name: string): Promise<UpdateGroup | null> {
+    const { data, error } = await this.supabase
+      .from(Tables.UPDATE_GROUPS)
+      .select()
+      .eq('name', name)
+      .maybeSingle();
+    if (error) throw new Error(error.message);
+    if (!data) return null;
+    return { id: data.id, name: data.name, isDefault: data.is_default, createdAt: data.created_at };
+  }
+
+  async getDefaultUpdateGroup(): Promise<UpdateGroup> {
+    const { data, error } = await this.supabase
+      .from(Tables.UPDATE_GROUPS)
+      .select()
+      .eq('is_default', true)
+      .maybeSingle();
+    if (error) throw new Error(error.message);
+    if (!data) throw new Error('No default update group configured');
+    return { id: data.id, name: data.name, isDefault: data.is_default, createdAt: data.created_at };
+  }
+
+  async createUpdateGroup(name: string): Promise<UpdateGroup> {
+    const { data, error } = await this.supabase
+      .from(Tables.UPDATE_GROUPS)
+      .insert({ name })
+      .select()
+      .single();
+    if (error) throw new Error(error.message);
+    return { id: data.id, name: data.name, isDefault: data.is_default, createdAt: data.created_at };
+  }
+
+  async deleteUpdateGroup(id: string): Promise<void> {
+    const { error } = await this.supabase
+      .from(Tables.UPDATE_GROUPS)
+      .delete()
+      .eq('id', id);
+    if (error) throw new Error(error.message);
+  }
+
+  async listGroupMembers(updateGroupId: string): Promise<UpdateGroupMember[]> {
+    const { data, error } = await this.supabase
+      .from(Tables.UPDATE_GROUP_MEMBERS)
+      .select()
+      .eq('update_group_id', updateGroupId)
+      .order('created_at', { ascending: false });
+    if (error) throw new Error(error.message);
+    return (data ?? []).map((m) => ({
+      updateGroupId: m.update_group_id,
+      userId: m.user_id,
+      createdAt: m.created_at,
+    }));
+  }
+
+  async addUserToGroup(updateGroupId: string, userId: string): Promise<void> {
+    const { error } = await this.supabase
+      .from(Tables.UPDATE_GROUP_MEMBERS)
+      .upsert(
+        { update_group_id: updateGroupId, user_id: userId },
+        { onConflict: 'update_group_id,user_id', ignoreDuplicates: true }
+      );
+    if (error) throw new Error(error.message);
+  }
+
+  async removeUserFromGroup(updateGroupId: string, userId: string): Promise<void> {
+    const { error } = await this.supabase
+      .from(Tables.UPDATE_GROUP_MEMBERS)
+      .delete()
+      .eq('update_group_id', updateGroupId)
+      .eq('user_id', userId);
+    if (error) throw new Error(error.message);
+  }
+
+  async getLatestReleaseForUser(
+    runtimeVersion: string,
+    userId: string | null
+  ): Promise<Release | null> {
+    if (userId) {
+      const { data: memberships, error: memErr } = await this.supabase
+        .from(Tables.UPDATE_GROUP_MEMBERS)
+        .select('update_group_id')
+        .eq('user_id', userId);
+      if (memErr) throw new Error(memErr.message);
+
+      const groupIds = (memberships ?? []).map((m: { update_group_id: string }) => m.update_group_id);
+      if (groupIds.length > 0) {
+        const { data, error } = await this.supabase
+          .from(Tables.RELEASES)
+          .select()
+          .eq('runtime_version', runtimeVersion)
+          .in('update_group_id', groupIds)
+          .order('timestamp', { ascending: false })
+          .limit(1)
+          .maybeSingle();
+        if (error) throw new Error(error.message);
+        if (data) return this.mapReleaseRow(data);
+      }
+    }
+
+    const defaultGroup = await this.getDefaultUpdateGroup();
+    const { data, error } = await this.supabase
+      .from(Tables.RELEASES)
+      .select()
+      .eq('runtime_version', runtimeVersion)
+      .eq('update_group_id', defaultGroup.id)
+      .order('timestamp', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    if (error) throw new Error(error.message);
+    return data ? this.mapReleaseRow(data) : null;
+  }
+
+  private mapReleaseRow(row: Record<string, unknown>): Release {
+    return {
+      id: row.id as string,
+      runtimeVersion: row.runtime_version as string,
+      path: row.path as string,
+      timestamp: row.timestamp as string,
+      commitHash: row.commit_hash as string,
+      commitMessage: row.commit_message as string,
+      updateId: row.update_id as string | undefined,
+      updateGroupId: row.update_group_id as string,
+    };
   }
 }

--- a/apiUtils/helpers/UpdateHelper.ts
+++ b/apiUtils/helpers/UpdateHelper.ts
@@ -2,8 +2,6 @@ import mime from 'mime';
 
 import { HashHelper } from './HashHelper';
 import { ZipHelper } from './ZipHelper';
-import { StorageFactory } from '../storage/StorageFactory';
-import { DatabaseFactory } from '../database/DatabaseFactory';
 
 export class NoUpdateAvailableError extends Error {}
 export type GetAssetMetadataArg =
@@ -14,6 +12,7 @@ export type GetAssetMetadataArg =
       isLaunchAsset: true;
       runtimeVersion: string;
       platform: string;
+      releaseId: string;
     }
   | {
       updateBundlePath: string;
@@ -22,44 +21,10 @@ export type GetAssetMetadataArg =
       isLaunchAsset: false;
       runtimeVersion: string;
       platform: string;
+      releaseId: string;
     };
 
 export class UpdateHelper {
-  static async getResolvedUpdateBundlePathAsync(
-    runtimeVersion: string,
-    userId: string | null
-  ): Promise<string> {
-    const release = await DatabaseFactory.getDatabase().getLatestReleaseForUser(
-      runtimeVersion,
-      userId
-    );
-    if (!release) {
-      throw new NoUpdateAvailableError();
-    }
-    return release.path.replace(/\.zip$/, '');
-  }
-
-  static async getLatestUpdateBundlePathForRuntimeVersionAsync(
-    runtimeVersion: string
-  ): Promise<string> {
-    const storage = StorageFactory.getStorage();
-    const updatesDirectoryForRuntimeVersion = `updates/${runtimeVersion}`;
-
-    if (!(await storage.fileExists(updatesDirectoryForRuntimeVersion))) {
-      throw new NoUpdateAvailableError();
-    }
-
-    const zipFiles = (await storage.listFiles(updatesDirectoryForRuntimeVersion))
-      .filter((file) => file.name.endsWith('.zip'))
-      .sort((a, b) => parseInt(b.name.split('.')[0], 10) - parseInt(a.name.split('.')[0], 10));
-
-    if (!zipFiles.length) {
-      throw new Error(`No updates found for runtime version: ${runtimeVersion}`);
-    }
-
-    return `${updatesDirectoryForRuntimeVersion}/${zipFiles[0].name.replace('.zip', '')}`;
-  }
-
   static async getAssetMetadataAsync(arg: GetAssetMetadataArg) {
     const zip = await ZipHelper.getZipFromStorage(arg.updateBundlePath);
     const asset = await ZipHelper.getFileFromZip(zip, arg.filePath);
@@ -76,7 +41,7 @@ export class UpdateHelper {
       key,
       fileExtension: `.${keyExtensionSuffix}`,
       contentType,
-      url: `${process.env.HOST}/api/assets?asset=${arg.filePath}&runtimeVersion=${arg.runtimeVersion}&platform=${arg.platform}`,
+      url: `${process.env.HOST}/api/assets?asset=${arg.filePath}&releaseId=${arg.releaseId}&runtimeVersion=${arg.runtimeVersion}&platform=${arg.platform}`,
     };
   }
 

--- a/apiUtils/helpers/UpdateHelper.ts
+++ b/apiUtils/helpers/UpdateHelper.ts
@@ -3,6 +3,7 @@ import mime from 'mime';
 import { HashHelper } from './HashHelper';
 import { ZipHelper } from './ZipHelper';
 import { StorageFactory } from '../storage/StorageFactory';
+import { DatabaseFactory } from '../database/DatabaseFactory';
 
 export class NoUpdateAvailableError extends Error {}
 export type GetAssetMetadataArg =
@@ -24,6 +25,20 @@ export type GetAssetMetadataArg =
     };
 
 export class UpdateHelper {
+  static async getResolvedUpdateBundlePathAsync(
+    runtimeVersion: string,
+    userId: string | null
+  ): Promise<string> {
+    const release = await DatabaseFactory.getDatabase().getLatestReleaseForUser(
+      runtimeVersion,
+      userId
+    );
+    if (!release) {
+      throw new NoUpdateAvailableError();
+    }
+    return release.path.replace(/\.zip$/, '');
+  }
+
   static async getLatestUpdateBundlePathForRuntimeVersionAsync(
     runtimeVersion: string
   ): Promise<string> {

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -12,7 +12,12 @@ export default function Layout({ children, ...props }: { children: React.ReactNo
     { name: 'Update groups', path: '/update-groups', icon: <FaLayerGroup fontSize="1.25rem" /> },
   ];
 
-  const handleLogout = () => {
+  const handleLogout = async () => {
+    try {
+      await fetch('/api/logout', { method: 'POST' });
+    } catch {
+      // best-effort; cookie may still be cleared by an expired session anyway
+    }
     localStorage.removeItem('isAuthenticated');
     router.push('/');
   };

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -1,6 +1,6 @@
 import { Box, Flex, VStack, Button, FlexProps } from '@chakra-ui/react';
 import { useRouter } from 'next/router';
-import { FaSignOutAlt, FaTachometerAlt, FaTags } from 'react-icons/fa';
+import { FaSignOutAlt, FaTachometerAlt, FaTags, FaLayerGroup } from 'react-icons/fa';
 import Image from 'next/image';
 
 export default function Layout({ children, ...props }: { children: React.ReactNode } & FlexProps) {
@@ -9,6 +9,7 @@ export default function Layout({ children, ...props }: { children: React.ReactNo
   const navItems = [
     { name: 'Dashboard', path: '/dashboard', icon: <FaTachometerAlt fontSize="1.25rem" /> },
     { name: 'Releases', path: '/releases', icon: <FaTags fontSize="1.25rem" /> },
+    { name: 'Update groups', path: '/update-groups', icon: <FaLayerGroup fontSize="1.25rem" /> },
   ];
 
   const handleLogout = () => {
@@ -25,7 +26,8 @@ export default function Layout({ children, ...props }: { children: React.ReactNo
         display="flex"
         alignItems="center"
         justifyContent="center"
-        position="relative">
+        position="relative"
+      >
         <Box>
           <Image
             src="/xavia_logo.png"
@@ -43,7 +45,8 @@ export default function Layout({ children, ...props }: { children: React.ReactNo
           className="h-full border-r-gray-200 border-r-2"
           display="flex"
           flexDirection="column"
-          justifyContent="space-between">
+          justifyContent="space-between"
+        >
           <VStack spacing={4} align="stretch">
             {navItems.map((item) => (
               <Button
@@ -52,7 +55,8 @@ export default function Layout({ children, ...props }: { children: React.ReactNo
                 colorScheme={router.pathname === item.path ? 'primary' : 'gray'}
                 rightIcon={item.icon}
                 onClick={() => router.push(item.path)}
-                justifyContent="space-between">
+                justifyContent="space-between"
+              >
                 <Box flex="1" textAlign="left">
                   {item.name}
                 </Box>
@@ -63,7 +67,8 @@ export default function Layout({ children, ...props }: { children: React.ReactNo
             variant="outline"
             colorScheme="red"
             onClick={handleLogout}
-            rightIcon={<FaSignOutAlt />}>
+            rightIcon={<FaSignOutAlt />}
+          >
             Logout
           </Button>
         </Box>

--- a/containers/database/docker-compose.yml
+++ b/containers/database/docker-compose.yml
@@ -2,16 +2,16 @@ services:
   xavia-postgres:
     image: postgres:14
     environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
-      POSTGRES_DB: releases_db
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      POSTGRES_DB: ${POSTGRES_DB:-releases_db}
     ports:
-      - '5432:5432'
+      - '${POSTGRES_PORT:-5432}:5432'
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./schema:/docker-entrypoint-initdb.d
     healthcheck:
-      test: ['CMD-SHELL', 'pg_isready -U postgres']
+      test: ['CMD-SHELL', 'pg_isready -U ${POSTGRES_USER:-postgres}']
       interval: 5s
       timeout: 5s
       retries: 5

--- a/containers/database/schema/update_groups.sql
+++ b/containers/database/schema/update_groups.sql
@@ -12,9 +12,13 @@ CREATE UNIQUE INDEX IF NOT EXISTS one_default_update_group
 CREATE TABLE IF NOT EXISTS update_group_members (
     update_group_id UUID NOT NULL REFERENCES update_groups(id) ON DELETE CASCADE,
     user_id VARCHAR(255) NOT NULL,
+    label VARCHAR(255),
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (update_group_id, user_id)
 );
+
+ALTER TABLE update_group_members
+    ADD COLUMN IF NOT EXISTS label VARCHAR(255);
 
 CREATE INDEX IF NOT EXISTS idx_update_group_members_user_id
     ON update_group_members(user_id);

--- a/containers/database/schema/update_groups.sql
+++ b/containers/database/schema/update_groups.sql
@@ -1,0 +1,34 @@
+CREATE TABLE IF NOT EXISTS update_groups (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name VARCHAR(255) NOT NULL UNIQUE,
+    is_default BOOLEAN NOT NULL DEFAULT false,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS one_default_update_group
+    ON update_groups ((is_default))
+    WHERE is_default = true;
+
+CREATE TABLE IF NOT EXISTS update_group_members (
+    update_group_id UUID NOT NULL REFERENCES update_groups(id) ON DELETE CASCADE,
+    user_id VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (update_group_id, user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_update_group_members_user_id
+    ON update_group_members(user_id);
+
+INSERT INTO update_groups (name, is_default)
+VALUES ('production', true)
+ON CONFLICT (name) DO NOTHING;
+
+ALTER TABLE releases
+    ADD COLUMN IF NOT EXISTS update_group_id UUID REFERENCES update_groups(id);
+
+UPDATE releases
+SET update_group_id = (SELECT id FROM update_groups WHERE is_default = true)
+WHERE update_group_id IS NULL;
+
+ALTER TABLE releases
+    ALTER COLUMN update_group_id SET NOT NULL;

--- a/docs/adminPortal.md
+++ b/docs/adminPortal.md
@@ -29,13 +29,20 @@ The `/update-groups` page lets operators manage release distribution. Each relea
 
 ### Identifying the user
 
-Manifest requests must send the user identifier as a header:
+Manifest requests carry the user identifier inside Expo's standard `Expo-Extra-Params` header. On the client, set it once at app startup:
+
+```ts
+import * as Updates from 'expo-updates';
+await Updates.setExtraParamAsync('xavia-user-id', currentUserId);
+```
+
+The Expo client serializes this as an RFC 8941 dictionary on every manifest poll, for example:
 
 ```
-xavia-user-id: <user id from your primary product database>
+Expo-Extra-Params: xavia-user-id="abc123"
 ```
 
-The header is treated as opaque. Missing or empty header → resolver uses the default group only.
+The server parses the dictionary, extracts the `xavia-user-id` value, and treats it as an opaque string. Missing key, missing header, or a malformed dictionary → the resolver falls back to the default group.
 
 ### Uploading to a group
 

--- a/docs/adminPortal.md
+++ b/docs/adminPortal.md
@@ -20,3 +20,34 @@ The release page provides:
 - List of all releases with metadata
 - Rollback functionality to a previous release
 
+## Update Groups
+
+The `/update-groups` page lets operators manage release distribution. Each release belongs to one update group; the manifest endpoint resolves the release a given client receives based on the user's group memberships.
+
+- A single group is flagged as the **default** (typically `production`). Every user implicitly belongs to it; it cannot be deleted or renamed from the UI.
+- Other groups (e.g. `beta`, per-customer diagnostic groups) hold explicit memberships. Users in any non-default group receive the latest release from that group, regardless of how recently the default group has shipped. Default is the fall-through when the user's groups have no release for the runtime version, or when no user id is supplied.
+
+### Identifying the user
+
+Manifest requests must send the user identifier as a header:
+
+```
+xavia-user-id: <user id from your primary product database>
+```
+
+The header is treated as opaque. Missing or empty header → resolver uses the default group only.
+
+### Uploading to a group
+
+`POST /api/upload` accepts an optional `updateGroup` form field containing the group **name** (not id). When omitted, the release lands in the default group. Unknown group names are rejected with `400`.
+
+### Rollback
+
+`POST /api/rollback` accepts an optional `updateGroup` field. When omitted, the new release inherits the source release's group. When supplied, the named group overrides the inherited one.
+
+### Operational guidance
+
+- Beta releases do not auto-inherit production patches. When a fix lands in production that should also be in beta, publish a new beta release containing the fix.
+- To move a user off a special build, remove them from the group; their next manifest poll falls through to the default group's latest release.
+- A group cannot be deleted while it owns releases — reassign or delete those releases first.
+

--- a/docs/superpowers/plans/2026-05-07-update-groups.md
+++ b/docs/superpowers/plans/2026-05-07-update-groups.md
@@ -1,0 +1,2175 @@
+# Update Groups Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the single global release distribution model with per-group releases. Beta and per-user diagnostic builds become possible. Resolver: non-default groups always win over the default; default acts as fallback.
+
+**Architecture:** Two new tables (`update_groups`, `update_group_members`) plus a new FK on `releases`. The manifest endpoint reads a `xavia-user-id` header and runs a two-step resolver: (1) newest release in the user's non-default groups, (2) fallback to newest release in the default group. Upload/rollback accept an optional group **name** and resolve to id server-side. Dashboard gets a groups admin page and a group selector in the upload form.
+
+**Tech Stack:** Next.js Pages Router, TypeScript, `pg` (Postgres) + Supabase JS, Chakra UI v2, Jest with `node-mocks-http`.
+
+**Spec:** `docs/superpowers/specs/2026-05-06-update-groups-design.md`
+
+---
+
+## File Structure
+
+**New files:**
+- `containers/database/schema/update_groups.sql` — schema migration for postgres dev/local
+- `pages/api/update-groups/index.ts` — `GET` list groups, `POST` create group
+- `pages/api/update-groups/[id].ts` — `DELETE` a group
+- `pages/api/update-groups/[id]/members.ts` — `GET` list members, `POST` add member, `DELETE` remove member
+- `pages/update-groups.tsx` — dashboard groups admin page
+- `__tests__/updateGroups.test.ts` — tests for the groups CRUD endpoints
+- `__tests__/updateGroupMembers.test.ts` — tests for the members endpoints
+
+**Modified files:**
+- `apiUtils/database/DatabaseFactory.ts` — add table enum entries
+- `apiUtils/database/DatabaseInterface.ts` — add `UpdateGroup` interface and method signatures, extend `Release`
+- `apiUtils/database/LocalDatabase.ts` — implement new methods
+- `apiUtils/database/SupabaseDatabase.ts` — implement new methods
+- `pages/api/manifest.ts` — read `xavia-user-id`, call new resolver
+- `pages/api/upload.ts` — accept `updateGroup` form field (name); look up id; use it
+- `pages/api/rollback.ts` — accept `updateGroup` (name); default to source release's group
+- `pages/api/releases.ts` — return group name per release
+- `pages/releases.tsx` — show group badge + filter; group selector in upload form
+- `__tests__/manifest.test.ts` — extend with group-aware cases
+- `__tests__/upload.test.ts` — extend with group field cases
+- `__tests__/rollback.test.ts` — extend with group inheritance cases
+- `__tests__/releases.test.ts` — extend with group name in response
+
+---
+
+## Task 1: Schema migration
+
+**Files:**
+- Create: `containers/database/schema/update_groups.sql`
+
+The existing schema files are mounted into postgres via `containers/database/docker-compose.yml` and run alphabetically on first boot (`releases.sql` → `tracking.sql` → `update_groups.sql`). For Supabase deployments, the operator applies the same SQL through the Supabase SQL editor.
+
+- [ ] **Step 1: Write the migration SQL**
+
+Create `containers/database/schema/update_groups.sql`:
+
+```sql
+CREATE TABLE IF NOT EXISTS update_groups (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name VARCHAR(255) NOT NULL UNIQUE,
+    is_default BOOLEAN NOT NULL DEFAULT false,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS one_default_update_group
+    ON update_groups ((is_default))
+    WHERE is_default = true;
+
+CREATE TABLE IF NOT EXISTS update_group_members (
+    update_group_id UUID NOT NULL REFERENCES update_groups(id) ON DELETE CASCADE,
+    user_id VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (update_group_id, user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_update_group_members_user_id
+    ON update_group_members(user_id);
+
+INSERT INTO update_groups (name, is_default)
+VALUES ('production', true)
+ON CONFLICT (name) DO NOTHING;
+
+ALTER TABLE releases
+    ADD COLUMN IF NOT EXISTS update_group_id UUID REFERENCES update_groups(id);
+
+UPDATE releases
+SET update_group_id = (SELECT id FROM update_groups WHERE is_default = true)
+WHERE update_group_id IS NULL;
+
+ALTER TABLE releases
+    ALTER COLUMN update_group_id SET NOT NULL;
+```
+
+- [ ] **Step 2: Verify against the docker-compose dev DB**
+
+```bash
+docker-compose -f containers/database/docker-compose.yml down -v
+docker-compose -f containers/database/docker-compose.yml up -d
+docker exec xavia-postgres psql -U postgres -d releases_db -c "\d update_groups"
+docker exec xavia-postgres psql -U postgres -d releases_db -c "\d update_group_members"
+docker exec xavia-postgres psql -U postgres -d releases_db -c "SELECT * FROM update_groups;"
+docker exec xavia-postgres psql -U postgres -d releases_db -c "\d releases"
+```
+
+Expected: tables exist, one row in `update_groups` with `is_default=true name=production`, `releases.update_group_id` is `NOT NULL`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add containers/database/schema/update_groups.sql
+git commit -m "feat(db): add update_groups and update_group_members tables"
+```
+
+---
+
+## Task 2: TypeScript interfaces
+
+**Files:**
+- Modify: `apiUtils/database/DatabaseInterface.ts`
+- Modify: `apiUtils/database/DatabaseFactory.ts`
+
+- [ ] **Step 1: Extend `Tables` enum**
+
+Edit `apiUtils/database/DatabaseFactory.ts`. Replace the `Tables` enum:
+
+```typescript
+export enum Tables {
+  RELEASES = 'releases',
+  RELEASES_TRACKING = 'releases_tracking',
+  UPDATE_GROUPS = 'update_groups',
+  UPDATE_GROUP_MEMBERS = 'update_group_members',
+}
+```
+
+- [ ] **Step 2: Add `UpdateGroup` interface and extend `Release`**
+
+Edit `apiUtils/database/DatabaseInterface.ts`. Replace the file with:
+
+```typescript
+export interface Release {
+  id: string;
+  runtimeVersion: string;
+  path: string;
+  timestamp: string;
+  commitHash: string;
+  commitMessage: string;
+  updateId?: string;
+  updateGroupId: string;
+  updateGroupName?: string;
+}
+
+export interface Tracking {
+  id: string;
+  releaseId: string;
+  downloadTimestamp: string;
+  platform: string;
+}
+
+export interface TrackingMetrics {
+  platform: string;
+  count: number;
+}
+
+export interface UpdateGroup {
+  id: string;
+  name: string;
+  isDefault: boolean;
+  createdAt: string;
+}
+
+export interface UpdateGroupMember {
+  updateGroupId: string;
+  userId: string;
+  createdAt: string;
+}
+
+export interface DatabaseInterface {
+  createRelease(release: Omit<Release, 'id' | 'updateGroupName'>): Promise<Release>;
+  getRelease(id: string): Promise<Release | null>;
+  getReleaseByPath(path: string): Promise<Release | null>;
+  listReleases(): Promise<Release[]>;
+  createTracking(tracking: Omit<Tracking, 'id'>): Promise<Tracking>;
+  getReleaseTrackingMetrics(releaseId: string): Promise<TrackingMetrics[]>;
+  getReleaseTrackingMetricsForAllReleases(): Promise<TrackingMetrics[]>;
+  getLatestReleaseRecordForRuntimeVersion(runtimeVersion: string): Promise<Release | null>;
+
+  // Update groups
+  listUpdateGroups(): Promise<UpdateGroup[]>;
+  getUpdateGroup(id: string): Promise<UpdateGroup | null>;
+  getUpdateGroupByName(name: string): Promise<UpdateGroup | null>;
+  getDefaultUpdateGroup(): Promise<UpdateGroup>;
+  createUpdateGroup(name: string): Promise<UpdateGroup>;
+  deleteUpdateGroup(id: string): Promise<void>;
+
+  // Membership
+  listGroupMembers(updateGroupId: string): Promise<UpdateGroupMember[]>;
+  addUserToGroup(updateGroupId: string, userId: string): Promise<void>;
+  removeUserFromGroup(updateGroupId: string, userId: string): Promise<void>;
+
+  // Resolver
+  getLatestReleaseForUser(
+    runtimeVersion: string,
+    userId: string | null
+  ): Promise<Release | null>;
+}
+```
+
+- [ ] **Step 3: Verify the codebase still type-checks against the new interface (it won't yet)**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: errors in `LocalDatabase.ts` and `SupabaseDatabase.ts` for the missing methods. That's the failing-test analogue here — the next task implements them.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apiUtils/database/DatabaseInterface.ts apiUtils/database/DatabaseFactory.ts
+git commit -m "feat(db): add UpdateGroup types and DatabaseInterface methods"
+```
+
+---
+
+## Task 3: Postgres implementation — group CRUD
+
+**Files:**
+- Modify: `apiUtils/database/LocalDatabase.ts`
+
+- [ ] **Step 1: Add group CRUD methods to `PostgresDatabase`**
+
+Append these methods inside the `PostgresDatabase` class (just before the closing `}`):
+
+```typescript
+  async listUpdateGroups(): Promise<UpdateGroup[]> {
+    const { rows } = await this.pool.query(`
+      SELECT id, name, is_default as "isDefault", created_at as "createdAt"
+      FROM ${Tables.UPDATE_GROUPS}
+      ORDER BY is_default DESC, name ASC
+    `);
+    return rows;
+  }
+
+  async getUpdateGroup(id: string): Promise<UpdateGroup | null> {
+    const { rows } = await this.pool.query(
+      `SELECT id, name, is_default as "isDefault", created_at as "createdAt"
+       FROM ${Tables.UPDATE_GROUPS} WHERE id = $1`,
+      [id]
+    );
+    return rows[0] || null;
+  }
+
+  async getUpdateGroupByName(name: string): Promise<UpdateGroup | null> {
+    const { rows } = await this.pool.query(
+      `SELECT id, name, is_default as "isDefault", created_at as "createdAt"
+       FROM ${Tables.UPDATE_GROUPS} WHERE name = $1`,
+      [name]
+    );
+    return rows[0] || null;
+  }
+
+  async getDefaultUpdateGroup(): Promise<UpdateGroup> {
+    const { rows } = await this.pool.query(
+      `SELECT id, name, is_default as "isDefault", created_at as "createdAt"
+       FROM ${Tables.UPDATE_GROUPS} WHERE is_default = true LIMIT 1`
+    );
+    if (!rows[0]) throw new Error('No default update group configured');
+    return rows[0];
+  }
+
+  async createUpdateGroup(name: string): Promise<UpdateGroup> {
+    const { rows } = await this.pool.query(
+      `INSERT INTO ${Tables.UPDATE_GROUPS} (name)
+       VALUES ($1)
+       RETURNING id, name, is_default as "isDefault", created_at as "createdAt"`,
+      [name]
+    );
+    return rows[0];
+  }
+
+  async deleteUpdateGroup(id: string): Promise<void> {
+    await this.pool.query(`DELETE FROM ${Tables.UPDATE_GROUPS} WHERE id = $1`, [id]);
+  }
+```
+
+Update the imports at the top of the file:
+
+```typescript
+import {
+  DatabaseInterface,
+  Release,
+  Tracking,
+  TrackingMetrics,
+  UpdateGroup,
+  UpdateGroupMember,
+} from './DatabaseInterface';
+```
+
+- [ ] **Step 2: Add membership methods**
+
+Continue inside `PostgresDatabase`:
+
+```typescript
+  async listGroupMembers(updateGroupId: string): Promise<UpdateGroupMember[]> {
+    const { rows } = await this.pool.query(
+      `SELECT update_group_id as "updateGroupId", user_id as "userId", created_at as "createdAt"
+       FROM ${Tables.UPDATE_GROUP_MEMBERS} WHERE update_group_id = $1
+       ORDER BY created_at DESC`,
+      [updateGroupId]
+    );
+    return rows;
+  }
+
+  async addUserToGroup(updateGroupId: string, userId: string): Promise<void> {
+    await this.pool.query(
+      `INSERT INTO ${Tables.UPDATE_GROUP_MEMBERS} (update_group_id, user_id)
+       VALUES ($1, $2)
+       ON CONFLICT DO NOTHING`,
+      [updateGroupId, userId]
+    );
+  }
+
+  async removeUserFromGroup(updateGroupId: string, userId: string): Promise<void> {
+    await this.pool.query(
+      `DELETE FROM ${Tables.UPDATE_GROUP_MEMBERS}
+       WHERE update_group_id = $1 AND user_id = $2`,
+      [updateGroupId, userId]
+    );
+  }
+```
+
+- [ ] **Step 3: Add the resolver**
+
+Continue inside `PostgresDatabase`:
+
+```typescript
+  async getLatestReleaseForUser(
+    runtimeVersion: string,
+    userId: string | null
+  ): Promise<Release | null> {
+    const baseSelect = `
+      SELECT r.id, r.runtime_version as "runtimeVersion", r.path, r.timestamp,
+             r.commit_hash as "commitHash", r.commit_message as "commitMessage",
+             r.update_id as "updateId", r.update_group_id as "updateGroupId"
+      FROM ${Tables.RELEASES} r
+    `;
+
+    if (userId) {
+      const groupQuery = `
+        ${baseSelect}
+        WHERE r.runtime_version = $1
+          AND r.update_group_id IN (
+            SELECT update_group_id FROM ${Tables.UPDATE_GROUP_MEMBERS} WHERE user_id = $2
+          )
+        ORDER BY r.timestamp DESC
+        LIMIT 1
+      `;
+      const groupResult = await this.pool.query(groupQuery, [runtimeVersion, userId]);
+      if (groupResult.rows[0]) return groupResult.rows[0];
+    }
+
+    const defaultQuery = `
+      ${baseSelect}
+      JOIN ${Tables.UPDATE_GROUPS} g ON r.update_group_id = g.id
+      WHERE r.runtime_version = $1 AND g.is_default = true
+      ORDER BY r.timestamp DESC
+      LIMIT 1
+    `;
+    const defaultResult = await this.pool.query(defaultQuery, [runtimeVersion]);
+    return defaultResult.rows[0] || null;
+  }
+```
+
+- [ ] **Step 4: Update `createRelease` to require `updateGroupId`**
+
+Replace the existing `createRelease` method body in `PostgresDatabase`:
+
+```typescript
+  async createRelease(release: Omit<Release, 'id' | 'updateGroupName'>): Promise<Release> {
+    const query = `
+      INSERT INTO ${Tables.RELEASES}
+        (runtime_version, path, timestamp, commit_hash, commit_message, update_id, update_group_id)
+      VALUES ($1, $2, $3, $4, $5, $6, $7)
+      RETURNING id, runtime_version as "runtimeVersion", path, timestamp,
+                commit_hash as "commitHash", commit_message as "commitMessage",
+                update_id as "updateId", update_group_id as "updateGroupId"
+    `;
+    const values = [
+      release.runtimeVersion,
+      release.path,
+      release.timestamp,
+      release.commitHash,
+      release.commitMessage,
+      release.updateId,
+      release.updateGroupId,
+    ];
+    const { rows } = await this.pool.query(query, values);
+    return rows[0];
+  }
+```
+
+- [ ] **Step 5: Update `listReleases` to JOIN group name**
+
+Replace `listReleases` in `PostgresDatabase`:
+
+```typescript
+  async listReleases(): Promise<Release[]> {
+    const query = `
+      SELECT r.id, r.runtime_version as "runtimeVersion", r.path, r.timestamp,
+             r.commit_hash as "commitHash", r.commit_message as "commitMessage",
+             r.update_id as "updateId", r.update_group_id as "updateGroupId",
+             g.name as "updateGroupName"
+      FROM ${Tables.RELEASES} r
+      LEFT JOIN ${Tables.UPDATE_GROUPS} g ON r.update_group_id = g.id
+      ORDER BY r.timestamp DESC
+    `;
+    const { rows } = await this.pool.query(query);
+    return rows;
+  }
+```
+
+- [ ] **Step 6: Type-check**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: no errors in `LocalDatabase.ts`. Errors may remain in `SupabaseDatabase.ts` — handled in the next task.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apiUtils/database/LocalDatabase.ts
+git commit -m "feat(db): postgres implementation for update groups"
+```
+
+---
+
+## Task 4: Supabase implementation — parity
+
+**Files:**
+- Modify: `apiUtils/database/SupabaseDatabase.ts`
+
+- [ ] **Step 1: Update imports**
+
+At the top of `apiUtils/database/SupabaseDatabase.ts`, replace the imports:
+
+```typescript
+import { createClient } from '@supabase/supabase-js';
+
+import {
+  DatabaseInterface,
+  Release,
+  Tracking,
+  TrackingMetrics,
+  UpdateGroup,
+  UpdateGroupMember,
+} from './DatabaseInterface';
+import { Tables } from './DatabaseFactory';
+```
+
+- [ ] **Step 2: Add group CRUD methods to `SupabaseDatabase`**
+
+Append inside the class:
+
+```typescript
+  async listUpdateGroups(): Promise<UpdateGroup[]> {
+    const { data, error } = await this.supabase
+      .from(Tables.UPDATE_GROUPS)
+      .select()
+      .order('is_default', { ascending: false })
+      .order('name', { ascending: true });
+    if (error) throw new Error(error.message);
+    return (data ?? []).map((g) => ({
+      id: g.id,
+      name: g.name,
+      isDefault: g.is_default,
+      createdAt: g.created_at,
+    }));
+  }
+
+  async getUpdateGroup(id: string): Promise<UpdateGroup | null> {
+    const { data, error } = await this.supabase
+      .from(Tables.UPDATE_GROUPS)
+      .select()
+      .eq('id', id)
+      .maybeSingle();
+    if (error) throw new Error(error.message);
+    if (!data) return null;
+    return { id: data.id, name: data.name, isDefault: data.is_default, createdAt: data.created_at };
+  }
+
+  async getUpdateGroupByName(name: string): Promise<UpdateGroup | null> {
+    const { data, error } = await this.supabase
+      .from(Tables.UPDATE_GROUPS)
+      .select()
+      .eq('name', name)
+      .maybeSingle();
+    if (error) throw new Error(error.message);
+    if (!data) return null;
+    return { id: data.id, name: data.name, isDefault: data.is_default, createdAt: data.created_at };
+  }
+
+  async getDefaultUpdateGroup(): Promise<UpdateGroup> {
+    const { data, error } = await this.supabase
+      .from(Tables.UPDATE_GROUPS)
+      .select()
+      .eq('is_default', true)
+      .maybeSingle();
+    if (error) throw new Error(error.message);
+    if (!data) throw new Error('No default update group configured');
+    return { id: data.id, name: data.name, isDefault: data.is_default, createdAt: data.created_at };
+  }
+
+  async createUpdateGroup(name: string): Promise<UpdateGroup> {
+    const { data, error } = await this.supabase
+      .from(Tables.UPDATE_GROUPS)
+      .insert({ name })
+      .select()
+      .single();
+    if (error) throw new Error(error.message);
+    return { id: data.id, name: data.name, isDefault: data.is_default, createdAt: data.created_at };
+  }
+
+  async deleteUpdateGroup(id: string): Promise<void> {
+    const { error } = await this.supabase
+      .from(Tables.UPDATE_GROUPS)
+      .delete()
+      .eq('id', id);
+    if (error) throw new Error(error.message);
+  }
+```
+
+- [ ] **Step 3: Add membership methods**
+
+```typescript
+  async listGroupMembers(updateGroupId: string): Promise<UpdateGroupMember[]> {
+    const { data, error } = await this.supabase
+      .from(Tables.UPDATE_GROUP_MEMBERS)
+      .select()
+      .eq('update_group_id', updateGroupId)
+      .order('created_at', { ascending: false });
+    if (error) throw new Error(error.message);
+    return (data ?? []).map((m) => ({
+      updateGroupId: m.update_group_id,
+      userId: m.user_id,
+      createdAt: m.created_at,
+    }));
+  }
+
+  async addUserToGroup(updateGroupId: string, userId: string): Promise<void> {
+    const { error } = await this.supabase
+      .from(Tables.UPDATE_GROUP_MEMBERS)
+      .upsert(
+        { update_group_id: updateGroupId, user_id: userId },
+        { onConflict: 'update_group_id,user_id', ignoreDuplicates: true }
+      );
+    if (error) throw new Error(error.message);
+  }
+
+  async removeUserFromGroup(updateGroupId: string, userId: string): Promise<void> {
+    const { error } = await this.supabase
+      .from(Tables.UPDATE_GROUP_MEMBERS)
+      .delete()
+      .eq('update_group_id', updateGroupId)
+      .eq('user_id', userId);
+    if (error) throw new Error(error.message);
+  }
+```
+
+- [ ] **Step 4: Add resolver**
+
+```typescript
+  async getLatestReleaseForUser(
+    runtimeVersion: string,
+    userId: string | null
+  ): Promise<Release | null> {
+    if (userId) {
+      const { data: memberships, error: memErr } = await this.supabase
+        .from(Tables.UPDATE_GROUP_MEMBERS)
+        .select('update_group_id')
+        .eq('user_id', userId);
+      if (memErr) throw new Error(memErr.message);
+
+      const groupIds = (memberships ?? []).map((m: { update_group_id: string }) => m.update_group_id);
+      if (groupIds.length > 0) {
+        const { data, error } = await this.supabase
+          .from(Tables.RELEASES)
+          .select()
+          .eq('runtime_version', runtimeVersion)
+          .in('update_group_id', groupIds)
+          .order('timestamp', { ascending: false })
+          .limit(1)
+          .maybeSingle();
+        if (error) throw new Error(error.message);
+        if (data) return this.mapReleaseRow(data);
+      }
+    }
+
+    const defaultGroup = await this.getDefaultUpdateGroup();
+    const { data, error } = await this.supabase
+      .from(Tables.RELEASES)
+      .select()
+      .eq('runtime_version', runtimeVersion)
+      .eq('update_group_id', defaultGroup.id)
+      .order('timestamp', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    if (error) throw new Error(error.message);
+    return data ? this.mapReleaseRow(data) : null;
+  }
+
+  private mapReleaseRow(row: Record<string, unknown>): Release {
+    return {
+      id: row.id as string,
+      runtimeVersion: row.runtime_version as string,
+      path: row.path as string,
+      timestamp: row.timestamp as string,
+      commitHash: row.commit_hash as string,
+      commitMessage: row.commit_message as string,
+      updateId: row.update_id as string | undefined,
+      updateGroupId: row.update_group_id as string,
+    };
+  }
+```
+
+- [ ] **Step 5: Update `createRelease` to include `update_group_id`**
+
+Replace the existing `createRelease` body:
+
+```typescript
+  async createRelease(release: Omit<Release, 'id' | 'updateGroupName'>): Promise<Release> {
+    const { data, error } = await this.supabase
+      .from(Tables.RELEASES)
+      .insert({
+        path: release.path,
+        runtime_version: release.runtimeVersion,
+        timestamp: release.timestamp,
+        commit_hash: release.commitHash,
+        commit_message: release.commitMessage,
+        update_id: release.updateId,
+        update_group_id: release.updateGroupId,
+      })
+      .select()
+      .single();
+    if (error) throw error;
+    return this.mapReleaseRow(data);
+  }
+```
+
+- [ ] **Step 6: Update `listReleases` to include group name**
+
+Replace `listReleases`:
+
+```typescript
+  async listReleases(): Promise<Release[]> {
+    const { data, error } = await this.supabase
+      .from(Tables.RELEASES)
+      .select(`*, ${Tables.UPDATE_GROUPS}(name)`)
+      .order('timestamp', { ascending: false });
+    if (error) throw error;
+    return (data ?? []).map((r) => ({
+      id: r.id,
+      path: r.path,
+      runtimeVersion: r.runtime_version,
+      timestamp: r.timestamp,
+      commitHash: r.commit_hash,
+      commitMessage: r.commit_message,
+      updateId: r.update_id,
+      updateGroupId: r.update_group_id,
+      updateGroupName: r[Tables.UPDATE_GROUPS]?.name,
+    }));
+  }
+```
+
+- [ ] **Step 7: Type-check**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apiUtils/database/SupabaseDatabase.ts
+git commit -m "feat(db): supabase implementation for update groups"
+```
+
+---
+
+## Task 5: API endpoints — groups CRUD
+
+**Files:**
+- Create: `pages/api/update-groups/index.ts`
+- Create: `pages/api/update-groups/[id].ts`
+- Create: `__tests__/updateGroups.test.ts`
+
+- [ ] **Step 1: Write failing tests for the index endpoint**
+
+Create `__tests__/updateGroups.test.ts`:
+
+```typescript
+import { createMocks } from 'node-mocks-http';
+
+import { DatabaseFactory } from '../apiUtils/database/DatabaseFactory';
+import indexHandler from '../pages/api/update-groups/index';
+import idHandler from '../pages/api/update-groups/[id]';
+
+jest.mock('../apiUtils/database/DatabaseFactory');
+
+describe('Update groups API', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('GET /api/update-groups returns the list', async () => {
+    const groups = [
+      { id: 'g1', name: 'production', isDefault: true, createdAt: 't' },
+      { id: 'g2', name: 'beta', isDefault: false, createdAt: 't' },
+    ];
+    const db = { listUpdateGroups: jest.fn().mockResolvedValue(groups) };
+    (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue(db);
+
+    const { req, res } = createMocks({ method: 'GET' });
+    await indexHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(JSON.parse(res._getData())).toEqual({ groups });
+  });
+
+  it('POST /api/update-groups creates a group', async () => {
+    const created = { id: 'g3', name: 'alpha', isDefault: false, createdAt: 't' };
+    const db = { createUpdateGroup: jest.fn().mockResolvedValue(created) };
+    (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue(db);
+
+    const { req, res } = createMocks({
+      method: 'POST',
+      body: { name: 'alpha' },
+    });
+    await indexHandler(req, res);
+
+    expect(db.createUpdateGroup).toHaveBeenCalledWith('alpha');
+    expect(res._getStatusCode()).toBe(201);
+    expect(JSON.parse(res._getData())).toEqual({ group: created });
+  });
+
+  it('POST /api/update-groups rejects missing name', async () => {
+    (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue({});
+    const { req, res } = createMocks({ method: 'POST', body: {} });
+    await indexHandler(req, res);
+    expect(res._getStatusCode()).toBe(400);
+  });
+
+  it('DELETE /api/update-groups/:id refuses if group is default', async () => {
+    const db = {
+      getUpdateGroup: jest.fn().mockResolvedValue({
+        id: 'g1', name: 'production', isDefault: true, createdAt: 't',
+      }),
+      deleteUpdateGroup: jest.fn(),
+    };
+    (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue(db);
+
+    const { req, res } = createMocks({ method: 'DELETE', query: { id: 'g1' } });
+    await idHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(db.deleteUpdateGroup).not.toHaveBeenCalled();
+  });
+
+  it('DELETE /api/update-groups/:id deletes a non-default group', async () => {
+    const db = {
+      getUpdateGroup: jest.fn().mockResolvedValue({
+        id: 'g2', name: 'beta', isDefault: false, createdAt: 't',
+      }),
+      deleteUpdateGroup: jest.fn().mockResolvedValue(undefined),
+    };
+    (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue(db);
+
+    const { req, res } = createMocks({ method: 'DELETE', query: { id: 'g2' } });
+    await idHandler(req, res);
+
+    expect(db.deleteUpdateGroup).toHaveBeenCalledWith('g2');
+    expect(res._getStatusCode()).toBe(204);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+```bash
+yarn test __tests__/updateGroups.test.ts
+```
+
+Expected: failures because the endpoint files don't exist.
+
+- [ ] **Step 3: Implement the index endpoint**
+
+Create `pages/api/update-groups/index.ts`:
+
+```typescript
+import { NextApiRequest, NextApiResponse } from 'next';
+
+import { DatabaseFactory } from '../../../apiUtils/database/DatabaseFactory';
+import { getLogger } from '../../../apiUtils/logger';
+
+const logger = getLogger('updateGroups');
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const db = DatabaseFactory.getDatabase();
+
+  if (req.method === 'GET') {
+    try {
+      const groups = await db.listUpdateGroups();
+      res.status(200).json({ groups });
+    } catch (error) {
+      logger.error(error);
+      res.status(500).json({ error: 'Failed to list update groups' });
+    }
+    return;
+  }
+
+  if (req.method === 'POST') {
+    const name = typeof req.body?.name === 'string' ? req.body.name.trim() : '';
+    if (!name) {
+      res.status(400).json({ error: 'Missing or empty `name`' });
+      return;
+    }
+    try {
+      const group = await db.createUpdateGroup(name);
+      res.status(201).json({ group });
+    } catch (error) {
+      logger.error(error);
+      res.status(500).json({ error: 'Failed to create update group' });
+    }
+    return;
+  }
+
+  res.status(405).json({ error: 'Method not allowed' });
+}
+```
+
+- [ ] **Step 4: Implement the [id] endpoint**
+
+Create `pages/api/update-groups/[id].ts`:
+
+```typescript
+import { NextApiRequest, NextApiResponse } from 'next';
+
+import { DatabaseFactory } from '../../../apiUtils/database/DatabaseFactory';
+import { getLogger } from '../../../apiUtils/logger';
+
+const logger = getLogger('updateGroup');
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { id } = req.query;
+  if (typeof id !== 'string') {
+    res.status(400).json({ error: 'Missing id' });
+    return;
+  }
+
+  const db = DatabaseFactory.getDatabase();
+
+  if (req.method === 'DELETE') {
+    try {
+      const group = await db.getUpdateGroup(id);
+      if (!group) {
+        res.status(404).json({ error: 'Update group not found' });
+        return;
+      }
+      if (group.isDefault) {
+        res.status(400).json({ error: 'Cannot delete the default update group' });
+        return;
+      }
+      await db.deleteUpdateGroup(id);
+      res.status(204).end();
+    } catch (error) {
+      logger.error(error);
+      res.status(500).json({ error: 'Failed to delete update group' });
+    }
+    return;
+  }
+
+  res.status(405).json({ error: 'Method not allowed' });
+}
+```
+
+- [ ] **Step 5: Run tests, verify they pass**
+
+```bash
+yarn test __tests__/updateGroups.test.ts
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pages/api/update-groups/index.ts pages/api/update-groups/[id].ts __tests__/updateGroups.test.ts
+git commit -m "feat(api): update groups CRUD endpoints"
+```
+
+---
+
+## Task 6: API endpoints — group membership
+
+**Files:**
+- Create: `pages/api/update-groups/[id]/members.ts`
+- Create: `__tests__/updateGroupMembers.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `__tests__/updateGroupMembers.test.ts`:
+
+```typescript
+import { createMocks } from 'node-mocks-http';
+
+import { DatabaseFactory } from '../apiUtils/database/DatabaseFactory';
+import membersHandler from '../pages/api/update-groups/[id]/members';
+
+jest.mock('../apiUtils/database/DatabaseFactory');
+
+describe('Update group members API', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('GET lists members', async () => {
+    const members = [{ updateGroupId: 'g1', userId: 'u1', createdAt: 't' }];
+    const db = {
+      getUpdateGroup: jest.fn().mockResolvedValue({ id: 'g1', name: 'beta', isDefault: false, createdAt: 't' }),
+      listGroupMembers: jest.fn().mockResolvedValue(members),
+    };
+    (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue(db);
+
+    const { req, res } = createMocks({ method: 'GET', query: { id: 'g1' } });
+    await membersHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(JSON.parse(res._getData())).toEqual({ members });
+  });
+
+  it('POST adds a member', async () => {
+    const db = {
+      getUpdateGroup: jest.fn().mockResolvedValue({ id: 'g1', name: 'beta', isDefault: false, createdAt: 't' }),
+      addUserToGroup: jest.fn().mockResolvedValue(undefined),
+    };
+    (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue(db);
+
+    const { req, res } = createMocks({
+      method: 'POST',
+      query: { id: 'g1' },
+      body: { userId: 'u42' },
+    });
+    await membersHandler(req, res);
+
+    expect(db.addUserToGroup).toHaveBeenCalledWith('g1', 'u42');
+    expect(res._getStatusCode()).toBe(204);
+  });
+
+  it('POST rejects missing userId', async () => {
+    const db = {
+      getUpdateGroup: jest.fn().mockResolvedValue({ id: 'g1', name: 'beta', isDefault: false, createdAt: 't' }),
+    };
+    (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue(db);
+    const { req, res } = createMocks({ method: 'POST', query: { id: 'g1' }, body: {} });
+    await membersHandler(req, res);
+    expect(res._getStatusCode()).toBe(400);
+  });
+
+  it('POST rejects when group is the default', async () => {
+    const db = {
+      getUpdateGroup: jest.fn().mockResolvedValue({ id: 'g1', name: 'production', isDefault: true, createdAt: 't' }),
+    };
+    (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue(db);
+    const { req, res } = createMocks({ method: 'POST', query: { id: 'g1' }, body: { userId: 'u1' } });
+    await membersHandler(req, res);
+    expect(res._getStatusCode()).toBe(400);
+  });
+
+  it('DELETE removes a member', async () => {
+    const db = {
+      getUpdateGroup: jest.fn().mockResolvedValue({ id: 'g1', name: 'beta', isDefault: false, createdAt: 't' }),
+      removeUserFromGroup: jest.fn().mockResolvedValue(undefined),
+    };
+    (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue(db);
+
+    const { req, res } = createMocks({
+      method: 'DELETE',
+      query: { id: 'g1', userId: 'u42' },
+    });
+    await membersHandler(req, res);
+
+    expect(db.removeUserFromGroup).toHaveBeenCalledWith('g1', 'u42');
+    expect(res._getStatusCode()).toBe(204);
+  });
+
+  it('returns 404 if group not found', async () => {
+    const db = { getUpdateGroup: jest.fn().mockResolvedValue(null) };
+    (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue(db);
+    const { req, res } = createMocks({ method: 'GET', query: { id: 'nope' } });
+    await membersHandler(req, res);
+    expect(res._getStatusCode()).toBe(404);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+```bash
+yarn test __tests__/updateGroupMembers.test.ts
+```
+
+Expected: cannot find handler.
+
+- [ ] **Step 3: Implement the members handler**
+
+Create `pages/api/update-groups/[id]/members.ts`:
+
+```typescript
+import { NextApiRequest, NextApiResponse } from 'next';
+
+import { DatabaseFactory } from '../../../../apiUtils/database/DatabaseFactory';
+import { getLogger } from '../../../../apiUtils/logger';
+
+const logger = getLogger('updateGroupMembers');
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { id } = req.query;
+  if (typeof id !== 'string') {
+    res.status(400).json({ error: 'Missing id' });
+    return;
+  }
+
+  const db = DatabaseFactory.getDatabase();
+  const group = await db.getUpdateGroup(id);
+  if (!group) {
+    res.status(404).json({ error: 'Update group not found' });
+    return;
+  }
+
+  if (req.method === 'GET') {
+    try {
+      const members = await db.listGroupMembers(id);
+      res.status(200).json({ members });
+    } catch (error) {
+      logger.error(error);
+      res.status(500).json({ error: 'Failed to list members' });
+    }
+    return;
+  }
+
+  if (req.method === 'POST') {
+    if (group.isDefault) {
+      res.status(400).json({ error: 'The default group has implicit membership and cannot have explicit members' });
+      return;
+    }
+    const userId = typeof req.body?.userId === 'string' ? req.body.userId.trim() : '';
+    if (!userId) {
+      res.status(400).json({ error: 'Missing or empty `userId`' });
+      return;
+    }
+    try {
+      await db.addUserToGroup(id, userId);
+      res.status(204).end();
+    } catch (error) {
+      logger.error(error);
+      res.status(500).json({ error: 'Failed to add member' });
+    }
+    return;
+  }
+
+  if (req.method === 'DELETE') {
+    const userId = typeof req.query.userId === 'string' ? req.query.userId : '';
+    if (!userId) {
+      res.status(400).json({ error: 'Missing `userId` query parameter' });
+      return;
+    }
+    try {
+      await db.removeUserFromGroup(id, userId);
+      res.status(204).end();
+    } catch (error) {
+      logger.error(error);
+      res.status(500).json({ error: 'Failed to remove member' });
+    }
+    return;
+  }
+
+  res.status(405).json({ error: 'Method not allowed' });
+}
+```
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+```bash
+yarn test __tests__/updateGroupMembers.test.ts
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pages/api/update-groups/[id]/members.ts __tests__/updateGroupMembers.test.ts
+git commit -m "feat(api): update group membership endpoints"
+```
+
+---
+
+## Task 7: Manifest endpoint — read user header, use resolver
+
+**Files:**
+- Modify: `pages/api/manifest.ts`
+- Modify: `apiUtils/helpers/UpdateHelper.ts`
+- Modify: `__tests__/manifest.test.ts`
+
+The manifest endpoint currently calls `UpdateHelper.getLatestUpdateBundlePathForRuntimeVersionAsync(runtimeVersion)`. We need that helper to consult the resolver so the chosen *bundle path* matches the resolved release.
+
+- [ ] **Step 1: Inspect the helper to understand current behavior**
+
+Read `apiUtils/helpers/UpdateHelper.ts` lines 1–50 to see how `getLatestUpdateBundlePathForRuntimeVersionAsync` is implemented. It currently lists files in storage and picks the newest. We will replace this logic with a DB-driven lookup.
+
+- [ ] **Step 2: Add a new resolver-based helper method**
+
+Edit `apiUtils/helpers/UpdateHelper.ts`. Add a static method on `UpdateHelper`:
+
+```typescript
+  static async getResolvedUpdateBundlePathAsync(
+    runtimeVersion: string,
+    userId: string | null
+  ): Promise<string> {
+    const release = await DatabaseFactory.getDatabase().getLatestReleaseForUser(
+      runtimeVersion,
+      userId
+    );
+    if (!release) {
+      throw new NoUpdateAvailableError();
+    }
+    // The path stored in the DB ends in `.zip`; the helper signature expects a path
+    // without the extension (matching prior behavior of `getLatestUpdateBundlePathForRuntimeVersionAsync`).
+    return release.path.replace(/\.zip$/, '');
+  }
+```
+
+If `DatabaseFactory` is not already imported at the top of the file, add:
+
+```typescript
+import { DatabaseFactory } from '../database/DatabaseFactory';
+```
+
+Leave `getLatestUpdateBundlePathForRuntimeVersionAsync` in place — it may still be used elsewhere; do not delete it in this task.
+
+- [ ] **Step 3: Update the manifest endpoint**
+
+Edit `pages/api/manifest.ts`. Replace lines 24–94 (the request-validation and bundle-resolution block) — concretely, two surgical edits:
+
+First, replace the logging block at the top of the handler (around line 24):
+
+```typescript
+  const userId =
+    typeof req.headers['xavia-user-id'] === 'string' && req.headers['xavia-user-id']
+      ? (req.headers['xavia-user-id'] as string)
+      : null;
+
+  logger.info('A client requested a release', {
+    runtimeVersion: req.headers['expo-runtime-version'],
+    platform: req.headers['expo-platform'],
+    protocolVersion: req.headers['expo-protocol-version'],
+    apiVersion: req.headers['expo-api-version'],
+    currentUpdateId: req.headers['expo-current-update-id'],
+    userId,
+  });
+```
+
+Second, replace the database lookup block (currently lines 61–94 — the call to `getLatestReleaseRecordForRuntimeVersion` and `UpdateHelper.getLatestUpdateBundlePathForRuntimeVersionAsync`) with:
+
+```typescript
+  const database = DatabaseFactory.getDatabase();
+  const releaseRecord = await database.getLatestReleaseForUser(runtimeVersion, userId);
+
+  if (releaseRecord) {
+    const updateId = releaseRecord.updateId;
+    const currentUpdateId = req.headers['expo-current-update-id'];
+    if (currentUpdateId === updateId) {
+      logger.info('User is already running the latest release. Returning NoUpdateAvailable.', {
+        runtimeVersion,
+        userId,
+      });
+      await putNoUpdateAvailableInResponseAsync(req, res, protocolVersion);
+      return;
+    }
+  }
+
+  let updateBundlePath: string;
+  try {
+    updateBundlePath = await UpdateHelper.getResolvedUpdateBundlePathAsync(runtimeVersion, userId);
+  } catch (error: any) {
+    if (error instanceof NoUpdateAvailableError) {
+      logger.info('No update available for runtime version', { runtimeVersion, userId });
+      await putNoUpdateAvailableInResponseAsync(req, res, protocolVersion);
+      return;
+    }
+    res.statusCode = 404;
+    res.json({ error: error.message });
+    return;
+  }
+```
+
+- [ ] **Step 4: Add manifest tests for group resolution**
+
+Append to `__tests__/manifest.test.ts` (inside the existing `describe` block):
+
+```typescript
+  it('passes xavia-user-id to the resolver', async () => {
+    const mockRelease = {
+      id: 'release-id',
+      runtimeVersion: '1.0.0',
+      path: 'updates/1.0.0/x.zip',
+      timestamp: '2024-03-20T00:00:00Z',
+      commitHash: 'abc',
+      commitMessage: 'msg',
+      updateId: 'uid-1',
+      updateGroupId: 'g-beta',
+    };
+    const getLatestReleaseForUser = jest.fn().mockResolvedValue(mockRelease);
+    (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue({
+      getLatestReleaseForUser,
+    });
+
+    (UpdateHelper.getResolvedUpdateBundlePathAsync as jest.Mock) = jest
+      .fn()
+      .mockResolvedValue('updates/1.0.0/x');
+
+    const { req, res } = createMocks({
+      method: 'GET',
+      headers: {
+        'expo-platform': 'ios',
+        'expo-runtime-version': '1.0.0',
+        'expo-protocol-version': '1',
+        'expo-current-update-id': 'uid-1',
+        'xavia-user-id': 'user-42',
+      },
+    });
+
+    await manifestEndpoint(req, res);
+
+    expect(getLatestReleaseForUser).toHaveBeenCalledWith('1.0.0', 'user-42');
+    expect(res._getStatusCode()).toBe(200);
+  });
+
+  it('treats missing xavia-user-id as anonymous (null userId)', async () => {
+    const getLatestReleaseForUser = jest.fn().mockResolvedValue(null);
+    (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue({
+      getLatestReleaseForUser,
+    });
+    (UpdateHelper.getResolvedUpdateBundlePathAsync as jest.Mock) = jest
+      .fn()
+      .mockRejectedValue(new NoUpdateAvailableError());
+
+    const { req, res } = createMocks({
+      method: 'GET',
+      headers: {
+        'expo-platform': 'ios',
+        'expo-runtime-version': '1.0.0',
+        'expo-protocol-version': '1',
+      },
+    });
+
+    await manifestEndpoint(req, res);
+
+    expect(getLatestReleaseForUser).toHaveBeenCalledWith('1.0.0', null);
+  });
+```
+
+- [ ] **Step 5: Run all manifest tests**
+
+```bash
+yarn test __tests__/manifest.test.ts
+```
+
+Expected: all tests pass. Snapshot tests may need updating — review the diff and run `yarn test -u __tests__/manifest.test.ts` if the only changes are additive log fields.
+
+- [ ] **Step 6: Type-check and lint**
+
+```bash
+npx tsc --noEmit
+yarn lint
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add pages/api/manifest.ts apiUtils/helpers/UpdateHelper.ts __tests__/manifest.test.ts
+git commit -m "feat(manifest): resolve releases per user via update groups"
+```
+
+---
+
+## Task 8: Upload — accept `updateGroup` name field
+
+**Files:**
+- Modify: `pages/api/upload.ts`
+- Modify: `__tests__/upload.test.ts`
+
+- [ ] **Step 1: Add a failing test**
+
+Open `__tests__/upload.test.ts`. Add inside the `describe('Upload API', ...)` block:
+
+```typescript
+  it('uses the named update group when provided', async () => {
+    const mockForm = {
+      parse: jest.fn().mockResolvedValue([
+        {
+          uploadKey: [process.env.UPLOAD_KEY],
+          runtimeVersion: ['1.0.0'],
+          commitHash: ['abc123'],
+          commitMessage: ['m'],
+          updateGroup: ['beta'],
+        },
+        { file: [{ filepath: 'test.zip' }] },
+      ]),
+    };
+    (formidable as unknown as jest.Mock).mockReturnValue(mockForm);
+
+    jest.spyOn(fs, 'readFileSync').mockReturnValue(Buffer.from('x'));
+    (AdmZip as unknown as jest.Mock).mockImplementation(() => ({} as AdmZip));
+    (ZipHelper.getFileFromZip as jest.Mock).mockResolvedValue(Buffer.from('{}'));
+    (HashHelper.createHash as jest.Mock).mockReturnValue('hash');
+    (HashHelper.convertSHA256HashToUUID as jest.Mock).mockReturnValue('uid');
+
+    const mockStorage = { uploadFile: jest.fn().mockResolvedValue('updates/1.0.0/t.zip') };
+    const createRelease = jest.fn().mockResolvedValue({});
+    const mockDatabase = {
+      getUpdateGroupByName: jest.fn().mockResolvedValue({
+        id: 'g-beta', name: 'beta', isDefault: false, createdAt: 't',
+      }),
+      getDefaultUpdateGroup: jest.fn(),
+      createRelease,
+    };
+    (StorageFactory.getStorage as jest.Mock).mockReturnValue(mockStorage);
+    (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue(mockDatabase);
+
+    const { req, res } = createMocks({ method: 'POST' });
+    await uploadHandler(req, res);
+
+    expect(mockDatabase.getUpdateGroupByName).toHaveBeenCalledWith('beta');
+    expect(mockDatabase.getDefaultUpdateGroup).not.toHaveBeenCalled();
+    expect(createRelease).toHaveBeenCalledWith(expect.objectContaining({ updateGroupId: 'g-beta' }));
+    expect(res._getStatusCode()).toBe(200);
+  });
+
+  it('falls back to the default group when updateGroup is omitted', async () => {
+    const mockForm = {
+      parse: jest.fn().mockResolvedValue([
+        {
+          uploadKey: [process.env.UPLOAD_KEY],
+          runtimeVersion: ['1.0.0'],
+          commitHash: ['abc'],
+          commitMessage: ['m'],
+        },
+        { file: [{ filepath: 'test.zip' }] },
+      ]),
+    };
+    (formidable as unknown as jest.Mock).mockReturnValue(mockForm);
+
+    jest.spyOn(fs, 'readFileSync').mockReturnValue(Buffer.from('x'));
+    (AdmZip as unknown as jest.Mock).mockImplementation(() => ({} as AdmZip));
+    (ZipHelper.getFileFromZip as jest.Mock).mockResolvedValue(Buffer.from('{}'));
+    (HashHelper.createHash as jest.Mock).mockReturnValue('hash');
+    (HashHelper.convertSHA256HashToUUID as jest.Mock).mockReturnValue('uid');
+
+    const createRelease = jest.fn().mockResolvedValue({});
+    const mockDatabase = {
+      getUpdateGroupByName: jest.fn(),
+      getDefaultUpdateGroup: jest.fn().mockResolvedValue({
+        id: 'g-prod', name: 'production', isDefault: true, createdAt: 't',
+      }),
+      createRelease,
+    };
+    (StorageFactory.getStorage as jest.Mock).mockReturnValue({
+      uploadFile: jest.fn().mockResolvedValue('updates/1.0.0/t.zip'),
+    });
+    (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue(mockDatabase);
+
+    const { req, res } = createMocks({ method: 'POST' });
+    await uploadHandler(req, res);
+
+    expect(mockDatabase.getDefaultUpdateGroup).toHaveBeenCalled();
+    expect(createRelease).toHaveBeenCalledWith(expect.objectContaining({ updateGroupId: 'g-prod' }));
+  });
+
+  it('rejects with 400 when updateGroup name is unknown', async () => {
+    const mockForm = {
+      parse: jest.fn().mockResolvedValue([
+        {
+          uploadKey: [process.env.UPLOAD_KEY],
+          runtimeVersion: ['1.0.0'],
+          commitHash: ['abc'],
+          commitMessage: ['m'],
+          updateGroup: ['nonexistent'],
+        },
+        { file: [{ filepath: 'test.zip' }] },
+      ]),
+    };
+    (formidable as unknown as jest.Mock).mockReturnValue(mockForm);
+
+    const mockDatabase = {
+      getUpdateGroupByName: jest.fn().mockResolvedValue(null),
+    };
+    (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue(mockDatabase);
+
+    const { req, res } = createMocks({ method: 'POST' });
+    await uploadHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+  });
+```
+
+- [ ] **Step 2: Run tests, confirm failure**
+
+```bash
+yarn test __tests__/upload.test.ts
+```
+
+Expected: the new tests fail.
+
+- [ ] **Step 3: Implement the change in `pages/api/upload.ts`**
+
+Replace the body inside the `try { ... }` block of `pages/api/upload.ts` from after the upload-key check through the `createRelease` call. The full revised handler body:
+
+```typescript
+    const [fields, files] = await form.parse(req);
+    const uploadKey = fields.uploadKey?.[0] || null;
+    const file = files.file?.[0];
+    const runtimeVersion = fields.runtimeVersion?.[0];
+    const commitHash = fields.commitHash?.[0];
+    const commitMessage = fields.commitMessage?.[0] || 'No message provided';
+    const updateGroupName = fields.updateGroup?.[0];
+
+    if (!uploadKey || !file || !runtimeVersion || !commitHash) {
+      res.status(400).json({ error: 'Missing upload key, file, runtime version or commit hash' });
+      return;
+    }
+
+    if (process.env.UPLOAD_KEY !== uploadKey) {
+      res.status(400).json({ error: 'Upload failed: wrong upload key' });
+      return;
+    }
+
+    const database = DatabaseFactory.getDatabase();
+    let updateGroup;
+    if (updateGroupName) {
+      updateGroup = await database.getUpdateGroupByName(updateGroupName);
+      if (!updateGroup) {
+        res.status(400).json({ error: `Unknown update group: ${updateGroupName}` });
+        return;
+      }
+    } else {
+      updateGroup = await database.getDefaultUpdateGroup();
+    }
+
+    const storage = StorageFactory.getStorage();
+    const timestamp = moment().utc().format('YYYYMMDDHHmmss');
+    const updatePath = `updates/${runtimeVersion}`;
+
+    const zipContent = fs.readFileSync(file.filepath);
+    const zipFolder = new AdmZip(file.filepath);
+    const metadataJsonFile = await ZipHelper.getFileFromZip(zipFolder, 'metadata.json');
+
+    const updateHash = HashHelper.createHash(metadataJsonFile, 'sha256', 'hex');
+    const updateId = HashHelper.convertSHA256HashToUUID(updateHash);
+
+    const path = await storage.uploadFile(`${updatePath}/${timestamp}.zip`, zipContent);
+
+    await database.createRelease({
+      path,
+      runtimeVersion,
+      timestamp: moment().utc().toString(),
+      commitHash,
+      commitMessage,
+      updateId,
+      updateGroupId: updateGroup.id,
+    });
+
+    res.status(200).json({ success: true, path });
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+yarn test __tests__/upload.test.ts
+```
+
+Expected: all tests pass (including pre-existing snapshots — none of them touch the new field).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pages/api/upload.ts __tests__/upload.test.ts
+git commit -m "feat(upload): accept updateGroup name field"
+```
+
+---
+
+## Task 9: Rollback — inherit/override group
+
+**Files:**
+- Modify: `pages/api/rollback.ts`
+- Modify: `__tests__/rollback.test.ts`
+
+- [ ] **Step 1: Add failing tests**
+
+Open `__tests__/rollback.test.ts`. Add inside the existing `describe` block:
+
+```typescript
+  it('inherits the source release group when no override is provided', async () => {
+    const mockStorage = { copyFile: jest.fn().mockResolvedValue(undefined) };
+    const createRelease = jest.fn().mockResolvedValue({});
+    const mockDatabase = {
+      getReleaseByPath: jest.fn().mockResolvedValue({
+        id: 'r1',
+        path: 'updates/1.0.0/old.zip',
+        runtimeVersion: '1.0.0',
+        timestamp: 't',
+        commitHash: 'h',
+        commitMessage: 'm',
+        updateGroupId: 'g-beta',
+      }),
+      getUpdateGroupByName: jest.fn(),
+      getDefaultUpdateGroup: jest.fn(),
+      createRelease,
+    };
+    (StorageFactory.getStorage as jest.Mock).mockReturnValue(mockStorage);
+    (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue(mockDatabase);
+
+    const { req, res } = createMocks({
+      method: 'POST',
+      body: {
+        path: 'updates/1.0.0/old.zip',
+        runtimeVersion: '1.0.0',
+        commitHash: 'h',
+        commitMessage: 'm',
+      },
+    });
+    await rollbackHandler(req, res);
+
+    expect(createRelease).toHaveBeenCalledWith(expect.objectContaining({ updateGroupId: 'g-beta' }));
+  });
+
+  it('honors the updateGroup override', async () => {
+    const mockStorage = { copyFile: jest.fn().mockResolvedValue(undefined) };
+    const createRelease = jest.fn().mockResolvedValue({});
+    const mockDatabase = {
+      getReleaseByPath: jest.fn().mockResolvedValue({
+        id: 'r1',
+        path: 'updates/1.0.0/old.zip',
+        runtimeVersion: '1.0.0',
+        timestamp: 't',
+        commitHash: 'h',
+        commitMessage: 'm',
+        updateGroupId: 'g-prod',
+      }),
+      getUpdateGroupByName: jest.fn().mockResolvedValue({
+        id: 'g-beta', name: 'beta', isDefault: false, createdAt: 't',
+      }),
+      createRelease,
+    };
+    (StorageFactory.getStorage as jest.Mock).mockReturnValue(mockStorage);
+    (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue(mockDatabase);
+
+    const { req, res } = createMocks({
+      method: 'POST',
+      body: {
+        path: 'updates/1.0.0/old.zip',
+        runtimeVersion: '1.0.0',
+        commitHash: 'h',
+        commitMessage: 'm',
+        updateGroup: 'beta',
+      },
+    });
+    await rollbackHandler(req, res);
+
+    expect(mockDatabase.getUpdateGroupByName).toHaveBeenCalledWith('beta');
+    expect(createRelease).toHaveBeenCalledWith(expect.objectContaining({ updateGroupId: 'g-beta' }));
+  });
+```
+
+If the test file does not already import the relevant modules, add at the top:
+
+```typescript
+import { DatabaseFactory } from '../apiUtils/database/DatabaseFactory';
+import { StorageFactory } from '../apiUtils/storage/StorageFactory';
+import rollbackHandler from '../pages/api/rollback';
+
+jest.mock('../apiUtils/database/DatabaseFactory');
+jest.mock('../apiUtils/storage/StorageFactory');
+```
+
+(They are likely already there — only add what is missing.)
+
+- [ ] **Step 2: Run tests, confirm failure**
+
+```bash
+yarn test __tests__/rollback.test.ts
+```
+
+- [ ] **Step 3: Update `pages/api/rollback.ts`**
+
+Replace the file with:
+
+```typescript
+import moment from 'moment';
+import { NextApiRequest, NextApiResponse } from 'next';
+
+import { DatabaseFactory } from '../../apiUtils/database/DatabaseFactory';
+import { StorageFactory } from '../../apiUtils/storage/StorageFactory';
+
+export default async function rollbackHandler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  const { path, runtimeVersion, commitHash, commitMessage, updateGroup: overrideGroupName } = req.body;
+
+  if (!path) {
+    res.status(400).json({ error: 'Missing path' });
+    return;
+  }
+  if (!runtimeVersion) {
+    res.status(400).json({ error: 'Missing runtimeVersion' });
+    return;
+  }
+  if (!commitHash) {
+    res.status(400).json({ error: 'Missing commitHash' });
+    return;
+  }
+
+  try {
+    const database = DatabaseFactory.getDatabase();
+    const storage = StorageFactory.getStorage();
+
+    let updateGroupId: string;
+    if (overrideGroupName) {
+      const overrideGroup = await database.getUpdateGroupByName(overrideGroupName);
+      if (!overrideGroup) {
+        res.status(400).json({ error: `Unknown update group: ${overrideGroupName}` });
+        return;
+      }
+      updateGroupId = overrideGroup.id;
+    } else {
+      const sourceRelease = await database.getReleaseByPath(path);
+      if (sourceRelease?.updateGroupId) {
+        updateGroupId = sourceRelease.updateGroupId;
+      } else {
+        const defaultGroup = await database.getDefaultUpdateGroup();
+        updateGroupId = defaultGroup.id;
+      }
+    }
+
+    const timestamp = moment().utc().format('YYYYMMDDHHmmss');
+    const newPath = `updates/${runtimeVersion}/${timestamp}.zip`;
+
+    await storage.copyFile(path, newPath);
+
+    await database.createRelease({
+      path: newPath,
+      runtimeVersion,
+      timestamp: moment().utc().toString(),
+      commitHash,
+      commitMessage,
+      updateGroupId,
+    });
+
+    res.status(200).json({ success: true, newPath });
+  } catch (error) {
+    console.error('Rollback error:', error);
+    res.status(500).json({ error: 'Rollback failed' });
+  }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+yarn test __tests__/rollback.test.ts
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pages/api/rollback.ts __tests__/rollback.test.ts
+git commit -m "feat(rollback): inherit/override update group"
+```
+
+---
+
+## Task 10: Releases listing — include group name
+
+**Files:**
+- Modify: `pages/api/releases.ts`
+- Modify: `__tests__/releases.test.ts`
+
+- [ ] **Step 1: Update the release-mapping logic**
+
+Edit `pages/api/releases.ts`. Replace the `releases.push({...})` block (around lines 26–35) with:
+
+```typescript
+        releases.push({
+          path: release?.path || `${folderPath}/${file.name}`,
+          runtimeVersion,
+          timestamp: file.created_at,
+          size: file.metadata.size,
+          commitHash,
+          commitMessage: release?.commitMessage,
+          updateGroupId: release?.updateGroupId,
+          updateGroupName: release?.updateGroupName,
+        });
+```
+
+- [ ] **Step 2: Add a test confirming the new fields propagate**
+
+Open `__tests__/releases.test.ts`. Add a test inside the existing `describe`:
+
+```typescript
+  it('includes update group fields on each release', async () => {
+    const mockStorage = {
+      listDirectories: jest.fn().mockResolvedValue(['1.0.0']),
+      listFiles: jest.fn().mockResolvedValue([
+        { name: 'a.zip', created_at: 't', metadata: { size: 1 } },
+      ]),
+    };
+    const mockDatabase = {
+      listReleases: jest.fn().mockResolvedValue([
+        {
+          id: 'r1',
+          path: 'updates/1.0.0/a.zip',
+          runtimeVersion: '1.0.0',
+          timestamp: 't',
+          commitHash: 'h',
+          commitMessage: 'm',
+          updateGroupId: 'g-beta',
+          updateGroupName: 'beta',
+        },
+      ]),
+    };
+    (StorageFactory.getStorage as jest.Mock).mockReturnValue(mockStorage);
+    (DatabaseFactory.getDatabase as jest.Mock).mockReturnValue(mockDatabase);
+
+    const { req, res } = createMocks({ method: 'GET' });
+    await releasesHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const { releases } = JSON.parse(res._getData());
+    expect(releases[0]).toEqual(expect.objectContaining({
+      updateGroupId: 'g-beta',
+      updateGroupName: 'beta',
+    }));
+  });
+```
+
+If `releasesHandler` and the factory mocks aren't already imported, add them.
+
+- [ ] **Step 3: Run tests**
+
+```bash
+yarn test __tests__/releases.test.ts
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add pages/api/releases.ts __tests__/releases.test.ts
+git commit -m "feat(releases): expose update group fields in listing"
+```
+
+---
+
+## Task 11: Dashboard — groups admin page
+
+**Files:**
+- Create: `pages/update-groups.tsx`
+
+This page is a thin Chakra UI form over the API endpoints written in Tasks 5 & 6. Follow the patterns in `pages/releases.tsx` for layout (Layout component, Chakra primitives, toast on success/error). No tests — UI verification is manual.
+
+- [ ] **Step 1: Read the existing dashboard pages for style reference**
+
+```bash
+head -80 pages/releases.tsx
+head -40 pages/dashboard.tsx
+```
+
+Note the use of `Layout`, `ProtectedRoute`, `useToast` (or `showToast` from `components/toast`).
+
+- [ ] **Step 2: Implement `pages/update-groups.tsx`**
+
+Create `pages/update-groups.tsx`:
+
+```tsx
+import { useEffect, useState } from 'react';
+import {
+  Box,
+  Button,
+  Flex,
+  Heading,
+  HStack,
+  Input,
+  List,
+  ListItem,
+  Spinner,
+  Text,
+  VStack,
+} from '@chakra-ui/react';
+
+import Layout from '../components/Layout';
+import ProtectedRoute from '../components/ProtectedRoute';
+import { showToast } from '../components/toast';
+
+type UpdateGroup = {
+  id: string;
+  name: string;
+  isDefault: boolean;
+  createdAt: string;
+};
+
+type Member = { updateGroupId: string; userId: string; createdAt: string };
+
+export default function UpdateGroupsPage() {
+  const [groups, setGroups] = useState<UpdateGroup[] | null>(null);
+  const [newName, setNewName] = useState('');
+  const [selected, setSelected] = useState<UpdateGroup | null>(null);
+  const [members, setMembers] = useState<Member[]>([]);
+  const [newMemberId, setNewMemberId] = useState('');
+
+  async function refreshGroups() {
+    const res = await fetch('/api/update-groups');
+    const json = await res.json();
+    setGroups(json.groups);
+  }
+
+  async function refreshMembers(group: UpdateGroup) {
+    const res = await fetch(`/api/update-groups/${group.id}/members`);
+    const json = await res.json();
+    setMembers(json.members);
+  }
+
+  useEffect(() => { refreshGroups(); }, []);
+  useEffect(() => { if (selected) refreshMembers(selected); }, [selected]);
+
+  async function createGroup() {
+    if (!newName.trim()) return;
+    const res = await fetch('/api/update-groups', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ name: newName.trim() }),
+    });
+    if (!res.ok) {
+      showToast('Failed to create group', 'error');
+      return;
+    }
+    setNewName('');
+    showToast('Group created', 'success');
+    refreshGroups();
+  }
+
+  async function deleteGroup(group: UpdateGroup) {
+    if (!confirm(`Delete group "${group.name}"?`)) return;
+    const res = await fetch(`/api/update-groups/${group.id}`, { method: 'DELETE' });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      showToast(err.error ?? 'Failed to delete group', 'error');
+      return;
+    }
+    if (selected?.id === group.id) setSelected(null);
+    refreshGroups();
+  }
+
+  async function addMember() {
+    if (!selected || !newMemberId.trim()) return;
+    const res = await fetch(`/api/update-groups/${selected.id}/members`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ userId: newMemberId.trim() }),
+    });
+    if (!res.ok) {
+      showToast('Failed to add member', 'error');
+      return;
+    }
+    setNewMemberId('');
+    refreshMembers(selected);
+  }
+
+  async function removeMember(userId: string) {
+    if (!selected) return;
+    const res = await fetch(
+      `/api/update-groups/${selected.id}/members?userId=${encodeURIComponent(userId)}`,
+      { method: 'DELETE' }
+    );
+    if (!res.ok) {
+      showToast('Failed to remove member', 'error');
+      return;
+    }
+    refreshMembers(selected);
+  }
+
+  return (
+    <ProtectedRoute>
+      <Layout>
+        <Heading mb={6}>Update Groups</Heading>
+        <Flex gap={8} align="flex-start">
+          <Box flex="1">
+            <Heading size="md" mb={3}>Groups</Heading>
+            {groups === null ? (
+              <Spinner />
+            ) : (
+              <List spacing={2}>
+                {groups.map((g) => (
+                  <ListItem
+                    key={g.id}
+                    p={3}
+                    borderWidth="1px"
+                    borderRadius="md"
+                    cursor="pointer"
+                    bg={selected?.id === g.id ? 'gray.50' : undefined}
+                    onClick={() => setSelected(g)}
+                  >
+                    <HStack justify="space-between">
+                      <Text fontWeight="medium">
+                        {g.name}{g.isDefault ? ' (default)' : ''}
+                      </Text>
+                      {!g.isDefault && (
+                        <Button size="xs" colorScheme="red" onClick={(e) => { e.stopPropagation(); deleteGroup(g); }}>
+                          Delete
+                        </Button>
+                      )}
+                    </HStack>
+                  </ListItem>
+                ))}
+              </List>
+            )}
+            <HStack mt={4}>
+              <Input
+                placeholder="New group name"
+                value={newName}
+                onChange={(e) => setNewName(e.target.value)}
+              />
+              <Button onClick={createGroup}>Create</Button>
+            </HStack>
+          </Box>
+
+          <Box flex="1">
+            <Heading size="md" mb={3}>
+              {selected ? `Members of "${selected.name}"` : 'Select a group'}
+            </Heading>
+            {selected && (
+              <VStack align="stretch" spacing={2}>
+                {selected.isDefault ? (
+                  <Text color="gray.600">
+                    The default group has implicit membership — every user is in it.
+                  </Text>
+                ) : (
+                  <>
+                    {members.length === 0 ? (
+                      <Text color="gray.600">No members yet.</Text>
+                    ) : (
+                      <List spacing={2}>
+                        {members.map((m) => (
+                          <ListItem key={m.userId} p={2} borderWidth="1px" borderRadius="md">
+                            <HStack justify="space-between">
+                              <Text>{m.userId}</Text>
+                              <Button size="xs" colorScheme="red" onClick={() => removeMember(m.userId)}>
+                                Remove
+                              </Button>
+                            </HStack>
+                          </ListItem>
+                        ))}
+                      </List>
+                    )}
+                    <HStack>
+                      <Input
+                        placeholder="User id"
+                        value={newMemberId}
+                        onChange={(e) => setNewMemberId(e.target.value)}
+                      />
+                      <Button onClick={addMember}>Add</Button>
+                    </HStack>
+                  </>
+                )}
+              </VStack>
+            )}
+          </Box>
+        </Flex>
+      </Layout>
+    </ProtectedRoute>
+  );
+}
+```
+
+- [ ] **Step 3: Verify the page renders against a local DB**
+
+```bash
+docker-compose -f containers/database/docker-compose.yml down -v
+docker-compose -f containers/database/docker-compose.yml up -d
+yarn dev
+```
+
+Visit `http://localhost:3001/update-groups`, log in, and verify:
+- The `production` (default) group is listed with the "default" tag and no Delete button.
+- You can create a new group, add a fake user id, and remove the member.
+
+- [ ] **Step 4: Type-check and lint**
+
+```bash
+npx tsc --noEmit
+yarn lint
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pages/update-groups.tsx
+git commit -m "feat(dashboard): groups admin page"
+```
+
+---
+
+## Task 12: Dashboard — group selector in upload, badge in releases list
+
+**Files:**
+- Modify: `pages/releases.tsx`
+- Modify: `components/Layout.tsx` (only if it has a nav menu)
+
+The releases page currently contains the upload form. We add a group selector populated from `/api/update-groups`, and a small badge on each release card showing its group.
+
+- [ ] **Step 1: Inspect the upload form section of `pages/releases.tsx`**
+
+Read `pages/releases.tsx` to locate the upload form (look for the field where `runtimeVersion` is captured; the group selector will sit next to it).
+
+- [ ] **Step 2: Add the group selector**
+
+In the form-state section of `pages/releases.tsx`, add:
+
+```typescript
+const [updateGroups, setUpdateGroups] = useState<{ id: string; name: string; isDefault: boolean }[]>([]);
+const [selectedGroupName, setSelectedGroupName] = useState<string>('');
+
+useEffect(() => {
+  fetch('/api/update-groups')
+    .then((r) => r.json())
+    .then((data) => {
+      setUpdateGroups(data.groups);
+      const def = data.groups.find((g: { isDefault: boolean }) => g.isDefault);
+      if (def) setSelectedGroupName(def.name);
+    });
+}, []);
+```
+
+In the upload form JSX (next to runtimeVersion), add:
+
+```tsx
+<FormControl>
+  <FormLabel>Update group</FormLabel>
+  <Select
+    value={selectedGroupName}
+    onChange={(e) => setSelectedGroupName(e.target.value)}
+  >
+    {updateGroups.map((g) => (
+      <option key={g.id} value={g.name}>
+        {g.name}{g.isDefault ? ' (default)' : ''}
+      </option>
+    ))}
+  </Select>
+</FormControl>
+```
+
+(Add `Select`, `FormControl`, `FormLabel` to the existing `@chakra-ui/react` import if not already present.)
+
+In the `handleSubmit` (or equivalent) function that builds the FormData for the upload POST, add:
+
+```typescript
+formData.append('updateGroup', selectedGroupName);
+```
+
+- [ ] **Step 3: Show the group on each release card**
+
+In the JSX where each release is rendered (look for where `runtimeVersion` and `commitMessage` are displayed), add a small badge:
+
+```tsx
+{release.updateGroupName && (
+  <Badge ml={2} colorScheme={release.updateGroupName === 'production' ? 'green' : 'purple'}>
+    {release.updateGroupName}
+  </Badge>
+)}
+```
+
+(Add `Badge` to the Chakra import.)
+
+- [ ] **Step 4: Add a navigation link if the layout supports one**
+
+If `components/Layout.tsx` has a nav menu, add a link to `/update-groups`. Open it and follow the existing pattern. If there is no nav structure, skip this step.
+
+- [ ] **Step 5: Manual verification**
+
+```bash
+yarn dev
+```
+
+- Upload a build with `updateGroup` selected as the new beta group; confirm in the database (or by calling `/api/releases`) that the release row references the correct group.
+- View the releases list; confirm the badge shows.
+- Try uploading without changing the selector; confirm the release lands in `production`.
+
+- [ ] **Step 6: Type-check and lint**
+
+```bash
+npx tsc --noEmit
+yarn lint
+yarn test
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add pages/releases.tsx components/Layout.tsx
+git commit -m "feat(dashboard): group selector + badge in releases page"
+```
+
+---
+
+## Task 13: Final verification
+
+- [ ] **Step 1: Run the full test suite**
+
+```bash
+yarn test
+```
+
+Expected: all tests pass. No skipped or pending tests introduced by this work.
+
+- [ ] **Step 2: Lint and type-check**
+
+```bash
+yarn lint
+npx tsc --noEmit
+```
+
+- [ ] **Step 3: Smoke test against a clean dev DB**
+
+```bash
+docker-compose -f containers/database/docker-compose.yml down -v
+docker-compose -f containers/database/docker-compose.yml up -d
+yarn dev
+```
+
+Manually exercise:
+1. `/update-groups` — create a `beta` group; add a fake user id `u-test`.
+2. Upload a release with `updateGroup=beta` (use the selector or a manual `curl` POST).
+3. Upload another release without specifying a group (lands in `production`).
+4. Hit `/api/manifest` (or use the Expo client) with `xavia-user-id: u-test` and confirm beta is served.
+5. Hit `/api/manifest` with no `xavia-user-id` and confirm production is served.
+6. Remove `u-test` from `beta`; confirm the next manifest poll resolves to production.
+7. Try to delete the `production` group from `/update-groups`; confirm the request is rejected.
+
+- [ ] **Step 4: Document the new envelope for callers**
+
+Add a note to `docs/adminPortal.md` (or create `docs/updateGroups.md` if `adminPortal.md` is unrelated) describing:
+- Header `xavia-user-id` is read by `/api/manifest`.
+- Upload accepts an `updateGroup` form field (name).
+- Rollback accepts an `updateGroup` field; otherwise inherits the source release's group.
+
+This is administrative documentation; one short paragraph each.
+
+- [ ] **Step 5: Commit and (optionally) open a PR**
+
+```bash
+git add docs/
+git commit -m "docs: document update groups admin workflow"
+```

--- a/docs/superpowers/specs/2026-05-06-update-groups-design.md
+++ b/docs/superpowers/specs/2026-05-06-update-groups-design.md
@@ -113,15 +113,16 @@ The rest of the endpoint (manifest construction, signing, multipart response, tr
 - `getLatestReleaseForUser(runtimeVersion: string, userId: string | null)` — returns the resolved release record, or `null`.
 - `listUpdateGroups()` / `getUpdateGroup(id)` / `createUpdateGroup(name)` / `deleteUpdateGroup(id)` — for dashboard CRUD.
 - `addUserToGroup(groupId, userId)` / `removeUserFromGroup(groupId, userId)` / `listGroupMembers(groupId)` / `listGroupsForUser(userId)`.
+- `getUpdateGroupByName(name)` — used by the upload and rollback handlers to resolve the name in the request to an id.
 - `createRelease` gains an optional `updateGroupId` parameter; defaults to the default group's id when omitted.
 
 The Supabase implementation mirrors the Postgres one, using the equivalent Supabase queries. The local-storage / no-DB code path is out of scope for groups — those installations effectively have only the default group.
 
 ## Upload, releases list, rollback
 
-- **Upload (`pages/api/upload.ts`):** Accept an optional `updateGroupId` form field. If absent, default to the default group. Validation: the supplied id must exist.
+- **Upload (`pages/api/upload.ts`):** Accept an optional `updateGroup` form field containing the group **name** (not ID). Names are easier to remember when uploading from a CI script or CLI. The handler resolves name → id; if no row matches, the request is rejected with 400. If absent, default to the default group.
 - **Releases list (`pages/api/releases.ts`):** Return `update_group_id` and group name alongside each release. The dashboard can filter by group.
-- **Rollback (`pages/api/rollback.ts`):** Inherit the source release's `update_group_id` for the new copy. The operator can override via a request field.
+- **Rollback (`pages/api/rollback.ts`):** Inherit the source release's group for the new copy. An optional `updateGroup` field (name, same convention as upload) overrides this.
 
 ## Dashboard UI
 

--- a/docs/superpowers/specs/2026-05-06-update-groups-design.md
+++ b/docs/superpowers/specs/2026-05-06-update-groups-design.md
@@ -5,9 +5,8 @@
 Replace the current "every release goes to everyone on a runtime version" distribution model with grouped releases. Each release belongs to one **update group** (e.g. `production`, `beta`, `acme-debug`). Users can be assigned to zero or more non-default groups. The manifest endpoint resolves the release a given user receives based on their group memberships.
 
 The motivating scenarios:
-- **Beta channel** — a stable subset of testers receives builds before production.
+- **Beta channel** — a stable subset of testers receives builds before production. Beta runs as its own track and is not interrupted by production patches.
 - **Per-customer / per-user diagnostic builds** — ship instrumentation or a one-off fix to a single user without affecting anyone else.
-- **Automatic cleanup** — when production catches up, special-purpose groups become irrelevant without manual intervention.
 
 ## Non-goals
 
@@ -57,31 +56,44 @@ ALTER TABLE releases
 
 ## Resolver
 
-The current rule is "latest release for this runtime version." The new rule is:
+The current rule is "latest release for this runtime version." The new rule is two-step:
 
-> Newest release (by `timestamp`) for this `runtime_version`, where `update_group_id` is either the default group or a group the requesting user belongs to.
+> 1. If the user belongs to any non-default groups, return the newest release (by `timestamp`) across those groups for this `runtime_version`.
+> 2. If step 1 returns nothing — either because the user is in zero non-default groups, or none of their groups has a release for this runtime version — return the newest release in the default group.
 
-In SQL:
+In SQL (single CTE-based query):
 
 ```sql
-SELECT r.*
-FROM releases r
-WHERE r.runtime_version = $1
-  AND r.update_group_id IN (
-    SELECT id FROM update_groups WHERE is_default = true
-    UNION
-    SELECT update_group_id FROM update_group_members WHERE user_id = $2
-  )
-ORDER BY r.timestamp DESC
+WITH user_group_release AS (
+  SELECT r.*
+  FROM releases r
+  WHERE r.runtime_version = $1
+    AND r.update_group_id IN (
+      SELECT update_group_id FROM update_group_members WHERE user_id = $2
+    )
+  ORDER BY r.timestamp DESC
+  LIMIT 1
+),
+default_release AS (
+  SELECT r.*
+  FROM releases r
+  JOIN update_groups g ON r.update_group_id = g.id
+  WHERE r.runtime_version = $1
+    AND g.is_default = true
+  ORDER BY r.timestamp DESC
+  LIMIT 1
+)
+SELECT * FROM user_group_release
+UNION ALL
+SELECT * FROM default_release WHERE NOT EXISTS (SELECT 1 FROM user_group_release)
 LIMIT 1;
 ```
 
-This single query produces the desired fall-through behavior:
-- A diagnostic build issued to one user is served to that user until production publishes something newer, at which point production wins automatically.
-- Beta testers get beta when beta is newer than prod, prod otherwise.
-- A user in zero non-default groups always receives the latest production release.
+**Why "non-default always wins" instead of "newest timestamp wins":** The naive timestamp rule causes silent regressions. A beta tester running release `B` (containing weeks of unreleased features) would be yanked back to production the moment any prod patch ships with a newer timestamp, since prod-patch's timestamp would beat `B`'s. The two-step rule keeps beta testers on beta unless beta has nothing for their runtime version.
 
-**No user ID supplied:** If the request omits the user ID header, the resolver uses only the default group. Same behavior as a user in zero groups. This preserves backward compatibility for older app builds that pre-date this feature.
+**Trade-off:** Beta does not automatically inherit production patches. If prod ships a fix that should also be in beta, the operator must publish a beta release that contains the fix. See "Operational guidance" below.
+
+**No user ID supplied:** If the request omits the user ID header, step 1 returns nothing and the resolver falls through to the default group. Same behavior as a user in zero non-default groups. This preserves backward compatibility for older app builds that pre-date this feature.
 
 ## Client identification
 
@@ -138,29 +150,39 @@ Upload form gets a group selector defaulting to the default group.
 | Case | Behavior |
 |---|---|
 | User in only default group | Always gets latest default release. |
-| User in `beta`, beta newer than prod | Gets beta. |
-| User in `beta`, prod ships something newer | Gets prod on next poll. Beta release becomes irrelevant. |
-| Diagnostic group with one user, you forget to clean it up | Self-heals on next prod release. Group can be deleted at any time after that. |
-| User removed from `beta` | Next manifest poll resolves against default group only — they will not be served any further beta releases. However, if they already downloaded a beta release, their app keeps running it until a newer release reachable to them (a new prod release, or a prod re-publish that bumps the timestamp) is available. Removal does not retroactively claw back a downloaded bundle. |
-| Group deleted while user is on one of its releases | `releases.update_group_id` would dangle. Solution: deleting a group requires the operator to first move or delete its releases. Enforced at the DB level via no `ON DELETE` cascade on the FK from `releases`. |
+| User in `beta`, beta has a release for this runtime version | Gets latest beta release, regardless of prod's timestamp. |
+| User in `beta`, prod ships a patch newer than the latest beta | Stays on beta. Prod patch is not visible to beta users until a beta release is published containing it. |
+| User in `beta`, beta has no release for this runtime version | Falls through to latest prod. (Safety net, e.g. when bumping runtime version.) |
+| User in `beta` + `acme-debug` | Newest release across the two non-default groups wins (timestamp tie-break). |
+| User in diagnostic group, prod ships fixes | User stays on diagnostic until operator removes them from the group. Cleanup is explicit, not automatic. |
+| User removed from `beta` | Next manifest poll resolves against default group only — they will not be served any further beta releases. They download whatever prod's latest is, even if older by timestamp than their currently-running beta build, because the bundle's update_id differs. |
+| Group deleted while it owns a release | Rejected. The FK from `releases.update_group_id` uses default `NO ACTION`, so deleting a group with releases fails. Operator must move or delete the releases first. Member rows cascade-delete and don't block deletion. |
 | Manifest request with no user ID header | Treated as anonymous → default group only. |
 | Two clients on the same `user_id` (multiple devices) | Both get the same resolved release, which is the desired behavior. |
 
-## Operational levers (the "force a user back to production" question)
+## Operational guidance
 
-The fall-through behavior handles cleanup automatically once production catches up. For situations where you need a user off a special build *immediately*:
+**Keeping beta ahead of prod.** Because non-default groups always win, beta users will not pick up prod patches automatically. Whenever a fix lands in prod that should also be in beta, the operator must publish a beta release that contains it. The recommended cadence: every prod release is accompanied by (or quickly followed by) a beta release built from a branch that has the prod commit merged in. Without this discipline, beta drifts behind prod over time.
 
-- **Re-publish the latest production release.** Bumps its timestamp past the special build. Cheapest option, no schema involved.
-- **Move the user out of the special group AND re-publish prod.** Same as above plus closes the door on subsequent special releases.
-- **Embedded rollback.** Out of scope for this work but available in the protocol if ever needed.
+**Forcing a user off a special build.** To move a user off a diagnostic or beta release:
+
+- **Remove the user from the group.** Their next manifest poll falls through to the default group, and they download the latest prod release on the next poll.
+- **Delete the group entirely** (after first reassigning or deleting its releases). All members fall through to prod.
+- **Embedded rollback.** Available in the protocol but not surfaced in the UI; out of scope for this work.
 
 These are documented operator workflows, not new features.
 
 ## Testing
 
-- Unit tests for the resolver query covering: anonymous user, user in default only, user in beta with beta newer, user in beta with prod newer, user in two non-default groups, runtime version with no releases, runtime version with releases only in groups the user can't access (anonymous user → default still wins; user with no access → no release returned, manifest endpoint returns no-update directive).
-- Integration test for `manifest.ts` exercising header presence and absence.
-- Migration test confirming pre-existing releases land in the default group.
+- Unit tests for the resolver query covering:
+  - Anonymous user (no header) → latest default release.
+  - User with no group memberships → latest default release.
+  - User in `beta`, beta has a release for the runtime version (older than prod's latest) → beta release. Confirms non-default wins regardless of prod timestamp.
+  - User in `beta`, beta has no release for the runtime version → falls through to latest default release.
+  - User in two non-default groups → newest by timestamp across the two.
+  - Runtime version with no releases at all → returns null; manifest endpoint emits no-update directive.
+- Integration test for `manifest.ts` exercising user-id header presence and absence, and confirming the resolved release is the one served.
+- Migration test confirming pre-existing releases land in the default group and `update_group_id` becomes `NOT NULL`.
 
 ## Out of scope (followups)
 

--- a/docs/superpowers/specs/2026-05-06-update-groups-design.md
+++ b/docs/superpowers/specs/2026-05-06-update-groups-design.md
@@ -1,0 +1,169 @@
+# Update Groups — Design
+
+## Goal
+
+Replace the current "every release goes to everyone on a runtime version" distribution model with grouped releases. Each release belongs to one **update group** (e.g. `production`, `beta`, `acme-debug`). Users can be assigned to zero or more non-default groups. The manifest endpoint resolves the release a given user receives based on their group memberships.
+
+The motivating scenarios:
+- **Beta channel** — a stable subset of testers receives builds before production.
+- **Per-customer / per-user diagnostic builds** — ship instrumentation or a one-off fix to a single user without affecting anyone else.
+- **Automatic cleanup** — when production catches up, special-purpose groups become irrelevant without manual intervention.
+
+## Non-goals
+
+- Hiding pre-release content from determined attackers. User identity is sent as a plain header; anyone who knows or guesses a user ID can pull any group's release. This is acceptable because builds contain in-development features, not confidential code.
+- App-store-compliance rollbacks. The `rollBackToEmbedded` directive in `manifest.ts` is left as-is (latent, not surfaced in the UI). It's not part of this work.
+- Group-aware tracking analytics. Existing `releases_tracking` continues to work as-is.
+
+## Data model
+
+Two new tables, one new column.
+
+```sql
+CREATE TABLE update_groups (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name VARCHAR(255) NOT NULL UNIQUE,
+    is_default BOOLEAN NOT NULL DEFAULT false,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Exactly one default group must exist.
+CREATE UNIQUE INDEX one_default_update_group
+    ON update_groups ((is_default))
+    WHERE is_default = true;
+
+CREATE TABLE update_group_members (
+    update_group_id UUID NOT NULL REFERENCES update_groups(id) ON DELETE CASCADE,
+    user_id VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (update_group_id, user_id)
+);
+
+CREATE INDEX idx_update_group_members_user_id
+    ON update_group_members(user_id);
+
+ALTER TABLE releases
+    ADD COLUMN update_group_id UUID REFERENCES update_groups(id);
+```
+
+**Migration:** A bootstrap migration creates a single `production` group with `is_default = true` and backfills `releases.update_group_id` to point at it for every existing row. After backfill, `update_group_id` becomes `NOT NULL`.
+
+**Membership semantics:**
+- The default group has no membership rows. Every user is implicitly in it.
+- A user with no rows in `update_group_members` is in only the default group.
+- `user_id` is a string, matching whatever identifier the client sends. No FK to a users table — that table lives in the primary product DB, not here.
+
+**Cardinality:** Each release belongs to exactly one group (single FK). Re-publishing a bundle to another group is `copyFile` + new row, same as the existing rollback flow.
+
+## Resolver
+
+The current rule is "latest release for this runtime version." The new rule is:
+
+> Newest release (by `timestamp`) for this `runtime_version`, where `update_group_id` is either the default group or a group the requesting user belongs to.
+
+In SQL:
+
+```sql
+SELECT r.*
+FROM releases r
+WHERE r.runtime_version = $1
+  AND r.update_group_id IN (
+    SELECT id FROM update_groups WHERE is_default = true
+    UNION
+    SELECT update_group_id FROM update_group_members WHERE user_id = $2
+  )
+ORDER BY r.timestamp DESC
+LIMIT 1;
+```
+
+This single query produces the desired fall-through behavior:
+- A diagnostic build issued to one user is served to that user until production publishes something newer, at which point production wins automatically.
+- Beta testers get beta when beta is newer than prod, prod otherwise.
+- A user in zero non-default groups always receives the latest production release.
+
+**No user ID supplied:** If the request omits the user ID header, the resolver uses only the default group. Same behavior as a user in zero groups. This preserves backward compatibility for older app builds that pre-date this feature.
+
+## Client identification
+
+The mobile app sends a header on each manifest poll:
+
+```
+xavia-user-id: <opaque user id from primary product DB>
+```
+
+The server reads it as a string and passes it to the resolver. No verification, no signing. If the header is absent or empty, the resolver behaves as described above (default group only).
+
+This is the explicit security trade-off: low-stakes preview content makes verification unnecessary. If that ever changes, the upgrade path is to add token-based auth without changing the data model.
+
+## Manifest endpoint changes
+
+In `pages/api/manifest.ts`:
+
+1. Read `xavia-user-id` from request headers (treat missing/empty as anonymous).
+2. Replace the call to `database.getLatestReleaseRecordForRuntimeVersion(runtimeVersion)` with a new resolver method `database.getLatestReleaseForUser(runtimeVersion, userId)` that runs the query above.
+3. Replace the call to `UpdateHelper.getLatestUpdateBundlePathForRuntimeVersionAsync` similarly — it must consult the resolver, not just the runtime version.
+4. The "already running this update" short-circuit at line 68 continues to work, but it now compares against the *resolved* release for the user, not the global latest. This avoids false "you already have it" responses when a user is moved between groups.
+
+The rest of the endpoint (manifest construction, signing, multipart response, tracking insert) is unchanged.
+
+## Database interface changes
+
+`apiUtils/database/DatabaseInterface.ts` gains methods:
+
+- `getLatestReleaseForUser(runtimeVersion: string, userId: string | null)` — returns the resolved release record, or `null`.
+- `listUpdateGroups()` / `getUpdateGroup(id)` / `createUpdateGroup(name)` / `deleteUpdateGroup(id)` — for dashboard CRUD.
+- `addUserToGroup(groupId, userId)` / `removeUserFromGroup(groupId, userId)` / `listGroupMembers(groupId)` / `listGroupsForUser(userId)`.
+- `createRelease` gains an optional `updateGroupId` parameter; defaults to the default group's id when omitted.
+
+The Supabase implementation mirrors the Postgres one, using the equivalent Supabase queries. The local-storage / no-DB code path is out of scope for groups — those installations effectively have only the default group.
+
+## Upload, releases list, rollback
+
+- **Upload (`pages/api/upload.ts`):** Accept an optional `updateGroupId` form field. If absent, default to the default group. Validation: the supplied id must exist.
+- **Releases list (`pages/api/releases.ts`):** Return `update_group_id` and group name alongside each release. The dashboard can filter by group.
+- **Rollback (`pages/api/rollback.ts`):** Inherit the source release's `update_group_id` for the new copy. The operator can override via a request field.
+
+## Dashboard UI
+
+Two new screens:
+
+- **Groups list / detail** — create groups, view members, add/remove members by user ID. The default group is read-only (cannot be renamed or deleted; default flag cannot be moved).
+- **Releases list filter** — group selector at the top of the existing releases page; release cards show their group as a badge.
+
+Upload form gets a group selector defaulting to the default group.
+
+## Edge cases and how they resolve
+
+| Case | Behavior |
+|---|---|
+| User in only default group | Always gets latest default release. |
+| User in `beta`, beta newer than prod | Gets beta. |
+| User in `beta`, prod ships something newer | Gets prod on next poll. Beta release becomes irrelevant. |
+| Diagnostic group with one user, you forget to clean it up | Self-heals on next prod release. Group can be deleted at any time after that. |
+| User removed from `beta` | Next manifest poll resolves against default group only — they will not be served any further beta releases. However, if they already downloaded a beta release, their app keeps running it until a newer release reachable to them (a new prod release, or a prod re-publish that bumps the timestamp) is available. Removal does not retroactively claw back a downloaded bundle. |
+| Group deleted while user is on one of its releases | `releases.update_group_id` would dangle. Solution: deleting a group requires the operator to first move or delete its releases. Enforced at the DB level via no `ON DELETE` cascade on the FK from `releases`. |
+| Manifest request with no user ID header | Treated as anonymous → default group only. |
+| Two clients on the same `user_id` (multiple devices) | Both get the same resolved release, which is the desired behavior. |
+
+## Operational levers (the "force a user back to production" question)
+
+The fall-through behavior handles cleanup automatically once production catches up. For situations where you need a user off a special build *immediately*:
+
+- **Re-publish the latest production release.** Bumps its timestamp past the special build. Cheapest option, no schema involved.
+- **Move the user out of the special group AND re-publish prod.** Same as above plus closes the door on subsequent special releases.
+- **Embedded rollback.** Out of scope for this work but available in the protocol if ever needed.
+
+These are documented operator workflows, not new features.
+
+## Testing
+
+- Unit tests for the resolver query covering: anonymous user, user in default only, user in beta with beta newer, user in beta with prod newer, user in two non-default groups, runtime version with no releases, runtime version with releases only in groups the user can't access (anonymous user → default still wins; user with no access → no release returned, manifest endpoint returns no-update directive).
+- Integration test for `manifest.ts` exercising header presence and absence.
+- Migration test confirming pre-existing releases land in the default group.
+
+## Out of scope (followups)
+
+- Group-aware download metrics in `releases_tracking`.
+- Authenticated user IDs (signed token / opaque per-user secret).
+- A dedicated upload flow for the embedded-rollback marker zip.
+- Many-to-many release-to-group relationships.

--- a/jest.config.js
+++ b/jest.config.js
@@ -14,6 +14,7 @@ const customJestConfig = {
   // if using TypeScript with a baseUrl set to the root directory then you need the below for alias' to work
   moduleDirectories: ['node_modules', '<rootDir>/'],
   setupFiles: ['<rootDir>/.jest/setEnvVars.js'],
+  testPathIgnorePatterns: ['/node_modules/', '<rootDir>/__tests__/helpers/'],
 };
 
 // createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async

--- a/pages/api/assets.ts
+++ b/pages/api/assets.ts
@@ -2,11 +2,12 @@ import mime from 'mime';
 import { NextApiRequest, NextApiResponse } from 'next';
 import nullthrows from 'nullthrows';
 
+import { DatabaseFactory } from '../../apiUtils/database/DatabaseFactory';
 import { UpdateHelper } from '../../apiUtils/helpers/UpdateHelper';
 import { ZipHelper } from '../../apiUtils/helpers/ZipHelper';
 
 export default async function assetsEndpoint(req: NextApiRequest, res: NextApiResponse) {
-  const { asset: assetPath, runtimeVersion, platform } = req.query;
+  const { asset: assetPath, releaseId, runtimeVersion, platform } = req.query;
 
   if (!assetPath || typeof assetPath !== 'string') {
     res.statusCode = 400;
@@ -26,15 +27,31 @@ export default async function assetsEndpoint(req: NextApiRequest, res: NextApiRe
     return;
   }
 
+  if (!releaseId || typeof releaseId !== 'string') {
+    res.statusCode = 400;
+    res.json({ error: 'No releaseId provided.' });
+    return;
+  }
+
   try {
-    const updateBundlePath = await UpdateHelper.getLatestUpdateBundlePathForRuntimeVersionAsync(
-      runtimeVersion as string
-    );
+    const release = await DatabaseFactory.getDatabase().getRelease(releaseId);
+    if (!release) {
+      res.statusCode = 404;
+      res.json({ error: 'Release not found.' });
+      return;
+    }
+    if (release.runtimeVersion !== runtimeVersion) {
+      res.statusCode = 400;
+      res.json({ error: 'runtimeVersion does not match release.' });
+      return;
+    }
+
+    const updateBundlePath = release.path.replace(/\.zip$/, '');
     const zip = await ZipHelper.getZipFromStorage(updateBundlePath);
 
     const { metadataJson } = await UpdateHelper.getMetadataAsync({
       updateBundlePath,
-      runtimeVersion: runtimeVersion as string,
+      runtimeVersion,
     });
 
     const assetMetadata = metadataJson.fileMetadata[platform].assets.find(
@@ -42,7 +59,7 @@ export default async function assetsEndpoint(req: NextApiRequest, res: NextApiRe
     );
     const isLaunchAsset = metadataJson.fileMetadata[platform].bundle === assetPath;
 
-    const asset = await ZipHelper.getFileFromZip(zip, assetPath as string);
+    const asset = await ZipHelper.getFileFromZip(zip, assetPath);
 
     res.statusCode = 200;
     res.setHeader(

--- a/pages/api/login.ts
+++ b/pages/api/login.ts
@@ -1,5 +1,7 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 
+import { issueSessionCookie } from '../../apiUtils/auth/session';
+
 export default async function loginEndpoint(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {
     res.status(405).json({ error: 'Method not allowed' });
@@ -15,6 +17,7 @@ export default async function loginEndpoint(req: NextApiRequest, res: NextApiRes
   }
 
   if (password === adminPassword) {
+    issueSessionCookie(res);
     res.status(200).json({ success: true });
   } else {
     res.status(401).json({ error: 'Invalid password' });

--- a/pages/api/logout.ts
+++ b/pages/api/logout.ts
@@ -1,0 +1,12 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+
+import { clearSessionCookie } from '../../apiUtils/auth/session';
+
+export default async function logoutEndpoint(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+  clearSessionCookie(res);
+  res.status(200).json({ success: true });
+}

--- a/pages/api/manifest.ts
+++ b/pages/api/manifest.ts
@@ -21,12 +21,18 @@ export default async function manifestEndpoint(req: NextApiRequest, res: NextApi
     return;
   }
 
+  const userId =
+    typeof req.headers['xavia-user-id'] === 'string' && req.headers['xavia-user-id']
+      ? (req.headers['xavia-user-id'] as string)
+      : null;
+
   logger.info('A client requested a release', {
     runtimeVersion: req.headers['expo-runtime-version'],
     platform: req.headers['expo-platform'],
     protocolVersion: req.headers['expo-protocol-version'],
     apiVersion: req.headers['expo-api-version'],
     currentUpdateId: req.headers['expo-current-update-id'],
+    userId,
   });
 
   const protocolVersionMaybeArray = req.headers['expo-protocol-version'];
@@ -59,7 +65,7 @@ export default async function manifestEndpoint(req: NextApiRequest, res: NextApi
   }
 
   const database = DatabaseFactory.getDatabase();
-  const releaseRecord = await database.getLatestReleaseRecordForRuntimeVersion(runtimeVersion);
+  const releaseRecord = await database.getLatestReleaseForUser(runtimeVersion, userId);
 
   if (releaseRecord) {
     const updateId = releaseRecord.updateId;
@@ -68,6 +74,7 @@ export default async function manifestEndpoint(req: NextApiRequest, res: NextApi
     if (currentUpdateId === updateId) {
       logger.info('User is already running the latest release. Returning NoUpdateAvailable.', {
         runtimeVersion,
+        userId,
       });
       await putNoUpdateAvailableInResponseAsync(req, res, protocolVersion);
       return;
@@ -76,12 +83,10 @@ export default async function manifestEndpoint(req: NextApiRequest, res: NextApi
 
   let updateBundlePath: string;
   try {
-    updateBundlePath = await UpdateHelper.getLatestUpdateBundlePathForRuntimeVersionAsync(
-      runtimeVersion
-    );
+    updateBundlePath = await UpdateHelper.getResolvedUpdateBundlePathAsync(runtimeVersion, userId);
   } catch (error: any) {
     if (error instanceof NoUpdateAvailableError) {
-      logger.info('No update available for runtime version', { runtimeVersion });
+      logger.info('No update available for runtime version', { runtimeVersion, userId });
       await putNoUpdateAvailableInResponseAsync(req, res, protocolVersion);
       return;
     }

--- a/pages/api/manifest.ts
+++ b/pages/api/manifest.ts
@@ -10,6 +10,7 @@ import { UpdateHelper, NoUpdateAvailableError } from '../../apiUtils/helpers/Upd
 import { ZipHelper } from '../../apiUtils/helpers/ZipHelper';
 import { getLogger } from '../../apiUtils/logger';
 import { DatabaseFactory } from '../../apiUtils/database/DatabaseFactory';
+import { Release } from '../../apiUtils/database/DatabaseInterface';
 import moment from 'moment';
 
 const logger = getLogger('manifest');
@@ -81,37 +82,28 @@ export default async function manifestEndpoint(req: NextApiRequest, res: NextApi
   const database = DatabaseFactory.getDatabase();
   const releaseRecord = await database.getLatestReleaseForUser(runtimeVersion, userId);
 
-  if (releaseRecord) {
-    const updateId = releaseRecord.updateId;
-
-    const currentUpdateId = req.headers['expo-current-update-id'];
-    if (currentUpdateId === updateId) {
-      logger.info('User is already running the latest release. Returning NoUpdateAvailable.', {
-        runtimeVersion,
-        userId,
-      });
+  if (!releaseRecord) {
+    logger.info('No update available for runtime version', { runtimeVersion, userId });
+    try {
       await putNoUpdateAvailableInResponseAsync(req, res, protocolVersion);
-      return;
+    } catch (error: any) {
+      res.statusCode = 404;
+      res.json({ error: error.message });
     }
-  }
-
-  let updateBundlePath: string;
-  try {
-    updateBundlePath = await UpdateHelper.getResolvedUpdateBundlePathAsync(runtimeVersion, userId);
-  } catch (error: any) {
-    if (error instanceof NoUpdateAvailableError) {
-      logger.info('No update available for runtime version', { runtimeVersion, userId });
-      await putNoUpdateAvailableInResponseAsync(req, res, protocolVersion);
-      return;
-    }
-
-    res.statusCode = 404;
-    res.json({
-      error: error.message,
-    });
     return;
   }
 
+  const currentUpdateId = req.headers['expo-current-update-id'];
+  if (currentUpdateId && currentUpdateId === releaseRecord.updateId) {
+    logger.info('User is already running the latest release. Returning NoUpdateAvailable.', {
+      runtimeVersion,
+      userId,
+    });
+    await putNoUpdateAvailableInResponseAsync(req, res, protocolVersion);
+    return;
+  }
+
+  const updateBundlePath = releaseRecord.path.replace(/\.zip$/, '');
   const updateType = await getTypeOfUpdateAsync(updateBundlePath);
 
   try {
@@ -121,6 +113,7 @@ export default async function manifestEndpoint(req: NextApiRequest, res: NextApi
         await putUpdateInResponseAsync(
           req,
           res,
+          releaseRecord,
           updateBundlePath,
           runtimeVersion,
           platform,
@@ -159,6 +152,7 @@ async function getTypeOfUpdateAsync(updateBundlePath: string): Promise<UpdateTyp
 async function putUpdateInResponseAsync(
   req: NextApiRequest,
   res: NextApiResponse,
+  release: Release,
   updateBundlePath: string,
   runtimeVersion: string,
   platform: string,
@@ -195,6 +189,7 @@ async function putUpdateInResponseAsync(
           runtimeVersion,
           platform,
           isLaunchAsset: false,
+          releaseId: release.id,
         })
       )
     ),
@@ -205,6 +200,7 @@ async function putUpdateInResponseAsync(
       runtimeVersion,
       platform,
       ext: null,
+      releaseId: release.id,
     }),
     metadata: {},
     extra: {
@@ -259,17 +255,12 @@ async function putUpdateInResponseAsync(
   res.write(form.getBuffer());
   res.end();
 
-  const database = DatabaseFactory.getDatabase();
-  const release = await database.getReleaseByPath(updateBundlePath + '.zip');
-
-  if (release) {
-    logger.info(`Tracking download for release.`, { releaseId: release.id });
-    await database.createTracking({
-      platform,
-      releaseId: release.id,
-      downloadTimestamp: moment().utc().toISOString(),
-    });
-  }
+  logger.info(`Tracking download for release.`, { releaseId: release.id });
+  await DatabaseFactory.getDatabase().createTracking({
+    platform,
+    releaseId: release.id,
+    downloadTimestamp: moment().utc().toISOString(),
+  });
 }
 
 async function putRollBackInResponseAsync(

--- a/pages/api/manifest.ts
+++ b/pages/api/manifest.ts
@@ -1,7 +1,7 @@
 import FormData from 'form-data';
 
 import { NextApiRequest, NextApiResponse } from 'next';
-import { serializeDictionary } from 'structured-headers';
+import { parseDictionary, serializeDictionary } from 'structured-headers';
 
 import { ConfigHelper } from '../../apiUtils/helpers/ConfigHelper';
 import { DictionaryHelper } from '../../apiUtils/helpers/DictionaryHelper';
@@ -14,6 +14,23 @@ import moment from 'moment';
 
 const logger = getLogger('manifest');
 
+// Expo-Extra-Params is an RFC 8941 structured-headers dictionary with string
+// values, e.g. `xavia-user-id="abc123", another-key="x"`. Set on the client
+// via `Updates.setExtraParamAsync(key, value)`.
+function extractExtraParam(req: NextApiRequest, key: string): string | null {
+  const header = req.headers['expo-extra-params'];
+  if (typeof header !== 'string' || header.length === 0) return null;
+  try {
+    const entry = parseDictionary(header).get(key);
+    if (!entry) return null;
+    const [bareItem] = entry;
+    return typeof bareItem === 'string' && bareItem.length > 0 ? bareItem : null;
+  } catch (error) {
+    logger.warn('Failed to parse Expo-Extra-Params', { error });
+    return null;
+  }
+}
+
 export default async function manifestEndpoint(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') {
     res.statusCode = 405;
@@ -21,10 +38,7 @@ export default async function manifestEndpoint(req: NextApiRequest, res: NextApi
     return;
   }
 
-  const userId =
-    typeof req.headers['xavia-user-id'] === 'string' && req.headers['xavia-user-id']
-      ? (req.headers['xavia-user-id'] as string)
-      : null;
+  const userId = extractExtraParam(req, 'xavia-user-id');
 
   logger.info('A client requested a release', {
     runtimeVersion: req.headers['expo-runtime-version'],

--- a/pages/api/releases.ts
+++ b/pages/api/releases.ts
@@ -1,5 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 
+import { requireSession } from '../../apiUtils/auth/session';
 import { DatabaseFactory } from '../../apiUtils/database/DatabaseFactory';
 import { StorageFactory } from '../../apiUtils/storage/StorageFactory';
 
@@ -8,6 +9,7 @@ export default async function releasesHandler(req: NextApiRequest, res: NextApiR
     res.status(405).json({ error: 'Method not allowed' });
     return;
   }
+  if (!requireSession(req, res)) return;
 
   try {
     const storage = StorageFactory.getStorage();

--- a/pages/api/releases.ts
+++ b/pages/api/releases.ts
@@ -31,6 +31,8 @@ export default async function releasesHandler(req: NextApiRequest, res: NextApiR
           size: file.metadata.size,
           commitHash,
           commitMessage: release?.commitMessage,
+          updateGroupId: release?.updateGroupId,
+          updateGroupName: release?.updateGroupName,
         });
       }
     }

--- a/pages/api/rollback.ts
+++ b/pages/api/rollback.ts
@@ -1,6 +1,7 @@
 import moment from 'moment';
 import { NextApiRequest, NextApiResponse } from 'next';
 
+import { requireSession } from '../../apiUtils/auth/session';
 import { DatabaseFactory } from '../../apiUtils/database/DatabaseFactory';
 import { StorageFactory } from '../../apiUtils/storage/StorageFactory';
 
@@ -9,6 +10,7 @@ export default async function rollbackHandler(req: NextApiRequest, res: NextApiR
     res.status(405).json({ error: 'Method not allowed' });
     return;
   }
+  if (!requireSession(req, res)) return;
 
   const {
     path,

--- a/pages/api/rollback.ts
+++ b/pages/api/rollback.ts
@@ -10,37 +10,55 @@ export default async function rollbackHandler(req: NextApiRequest, res: NextApiR
     return;
   }
 
-  const { path, runtimeVersion, commitHash, commitMessage } = req.body;
+  const { path, runtimeVersion, commitHash, commitMessage, updateGroup: overrideGroupName } = req.body;
 
   if (!path) {
     res.status(400).json({ error: 'Missing path' });
     return;
   }
-
   if (!runtimeVersion) {
     res.status(400).json({ error: 'Missing runtimeVersion' });
     return;
   }
-
   if (!commitHash) {
     res.status(400).json({ error: 'Missing commitHash' });
     return;
   }
 
   try {
+    const database = DatabaseFactory.getDatabase();
     const storage = StorageFactory.getStorage();
+
+    let updateGroupId: string;
+    if (overrideGroupName) {
+      const overrideGroup = await database.getUpdateGroupByName(overrideGroupName);
+      if (!overrideGroup) {
+        res.status(400).json({ error: `Unknown update group: ${overrideGroupName}` });
+        return;
+      }
+      updateGroupId = overrideGroup.id;
+    } else {
+      const sourceRelease = await database.getReleaseByPath(path);
+      if (sourceRelease?.updateGroupId) {
+        updateGroupId = sourceRelease.updateGroupId;
+      } else {
+        const defaultGroup = await database.getDefaultUpdateGroup();
+        updateGroupId = defaultGroup.id;
+      }
+    }
 
     const timestamp = moment().utc().format('YYYYMMDDHHmmss');
     const newPath = `updates/${runtimeVersion}/${timestamp}.zip`;
 
     await storage.copyFile(path, newPath);
 
-    await DatabaseFactory.getDatabase().createRelease({
+    await database.createRelease({
       path: newPath,
       runtimeVersion,
       timestamp: moment().utc().toString(),
       commitHash,
       commitMessage,
+      updateGroupId,
     });
 
     res.status(200).json({ success: true, newPath });

--- a/pages/api/rollback.ts
+++ b/pages/api/rollback.ts
@@ -10,7 +10,13 @@ export default async function rollbackHandler(req: NextApiRequest, res: NextApiR
     return;
   }
 
-  const { path, runtimeVersion, commitHash, commitMessage, updateGroup: overrideGroupName } = req.body;
+  const {
+    path,
+    runtimeVersion,
+    commitHash,
+    commitMessage,
+    updateGroup: overrideGroupName,
+  } = req.body;
 
   if (!path) {
     res.status(400).json({ error: 'Missing path' });

--- a/pages/api/tracking/[release_id].ts
+++ b/pages/api/tracking/[release_id].ts
@@ -1,4 +1,5 @@
 import { NextApiRequest, NextApiResponse } from 'next';
+import { requireSession } from '../../../apiUtils/auth/session';
 import { DatabaseFactory } from '../../../apiUtils/database/DatabaseFactory';
 import { getLogger } from '../../../apiUtils/logger';
 
@@ -9,6 +10,7 @@ export default async function trackingByReleaseHandler(req: NextApiRequest, res:
     res.status(405).json({ error: 'Method not allowed' });
     return;
   }
+  if (!requireSession(req, res)) return;
 
   const { release_id } = req.query;
 

--- a/pages/api/tracking/all.ts
+++ b/pages/api/tracking/all.ts
@@ -1,4 +1,5 @@
 import { NextApiRequest, NextApiResponse } from 'next';
+import { requireSession } from '../../../apiUtils/auth/session';
 import { DatabaseFactory } from '../../../apiUtils/database/DatabaseFactory';
 import { getLogger } from '../../../apiUtils/logger';
 import { TrackingMetrics } from '../../../apiUtils/database/DatabaseInterface';
@@ -15,6 +16,7 @@ export default async function allTrackingHandler(req: NextApiRequest, res: NextA
     res.status(405).json({ error: 'Method not allowed' });
     return;
   }
+  if (!requireSession(req, res)) return;
 
   logger.info('Fetching all tracking data for all releases');
 

--- a/pages/api/update-groups/[id].ts
+++ b/pages/api/update-groups/[id].ts
@@ -1,0 +1,38 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+
+import { DatabaseFactory } from '../../../apiUtils/database/DatabaseFactory';
+import { getLogger } from '../../../apiUtils/logger';
+
+const logger = getLogger('updateGroup');
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { id } = req.query;
+  if (typeof id !== 'string') {
+    res.status(400).json({ error: 'Missing id' });
+    return;
+  }
+
+  const db = DatabaseFactory.getDatabase();
+
+  if (req.method === 'DELETE') {
+    try {
+      const group = await db.getUpdateGroup(id);
+      if (!group) {
+        res.status(404).json({ error: 'Update group not found' });
+        return;
+      }
+      if (group.isDefault) {
+        res.status(400).json({ error: 'Cannot delete the default update group' });
+        return;
+      }
+      await db.deleteUpdateGroup(id);
+      res.status(204).end();
+    } catch (error) {
+      logger.error(error);
+      res.status(500).json({ error: 'Failed to delete update group' });
+    }
+    return;
+  }
+
+  res.status(405).json({ error: 'Method not allowed' });
+}

--- a/pages/api/update-groups/[id].ts
+++ b/pages/api/update-groups/[id].ts
@@ -1,11 +1,13 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 
+import { requireSession } from '../../../apiUtils/auth/session';
 import { DatabaseFactory } from '../../../apiUtils/database/DatabaseFactory';
 import { getLogger } from '../../../apiUtils/logger';
 
 const logger = getLogger('updateGroup');
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (!requireSession(req, res)) return;
   const { id } = req.query;
   if (typeof id !== 'string') {
     res.status(400).json({ error: 'Missing id' });

--- a/pages/api/update-groups/[id]/members.ts
+++ b/pages/api/update-groups/[id]/members.ts
@@ -1,11 +1,13 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 
+import { requireSession } from '../../../../apiUtils/auth/session';
 import { DatabaseFactory } from '../../../../apiUtils/database/DatabaseFactory';
 import { getLogger } from '../../../../apiUtils/logger';
 
 const logger = getLogger('updateGroupMembers');
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (!requireSession(req, res)) return;
   const { id } = req.query;
   if (typeof id !== 'string') {
     res.status(400).json({ error: 'Missing id' });

--- a/pages/api/update-groups/[id]/members.ts
+++ b/pages/api/update-groups/[id]/members.ts
@@ -32,7 +32,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   if (req.method === 'POST') {
     if (group.isDefault) {
-      res.status(400).json({ error: 'The default group has implicit membership and cannot have explicit members' });
+      res.status(400).json({
+        error: 'The default group has implicit membership and cannot have explicit members',
+      });
       return;
     }
     const userId = typeof req.body?.userId === 'string' ? req.body.userId.trim() : '';

--- a/pages/api/update-groups/[id]/members.ts
+++ b/pages/api/update-groups/[id]/members.ts
@@ -1,0 +1,70 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+
+import { DatabaseFactory } from '../../../../apiUtils/database/DatabaseFactory';
+import { getLogger } from '../../../../apiUtils/logger';
+
+const logger = getLogger('updateGroupMembers');
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { id } = req.query;
+  if (typeof id !== 'string') {
+    res.status(400).json({ error: 'Missing id' });
+    return;
+  }
+
+  const db = DatabaseFactory.getDatabase();
+  const group = await db.getUpdateGroup(id);
+  if (!group) {
+    res.status(404).json({ error: 'Update group not found' });
+    return;
+  }
+
+  if (req.method === 'GET') {
+    try {
+      const members = await db.listGroupMembers(id);
+      res.status(200).json({ members });
+    } catch (error) {
+      logger.error(error);
+      res.status(500).json({ error: 'Failed to list members' });
+    }
+    return;
+  }
+
+  if (req.method === 'POST') {
+    if (group.isDefault) {
+      res.status(400).json({ error: 'The default group has implicit membership and cannot have explicit members' });
+      return;
+    }
+    const userId = typeof req.body?.userId === 'string' ? req.body.userId.trim() : '';
+    if (!userId) {
+      res.status(400).json({ error: 'Missing or empty `userId`' });
+      return;
+    }
+    try {
+      await db.addUserToGroup(id, userId);
+      res.status(204).end();
+    } catch (error) {
+      logger.error(error);
+      res.status(500).json({ error: 'Failed to add member' });
+    }
+    return;
+  }
+
+  if (req.method === 'DELETE') {
+    const userId = typeof req.query.userId === 'string' ? req.query.userId : '';
+    if (!userId) {
+      res.status(400).json({ error: 'Missing `userId` query parameter' });
+      return;
+    }
+    try {
+      await db.removeUserFromGroup(id, userId);
+      res.status(204).end();
+    } catch (error) {
+      logger.error(error);
+      res.status(500).json({ error: 'Failed to remove member' });
+    }
+    return;
+  }
+
+  res.status(405).json({ error: 'Method not allowed' });
+}

--- a/pages/api/update-groups/[id]/members.ts
+++ b/pages/api/update-groups/[id]/members.ts
@@ -42,8 +42,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       res.status(400).json({ error: 'Missing or empty `userId`' });
       return;
     }
+    const label =
+      typeof req.body?.label === 'string' ? req.body.label.trim() || undefined : undefined;
     try {
-      await db.addUserToGroup(id, userId);
+      await db.addUserToGroup(id, userId, label);
       res.status(204).end();
     } catch (error) {
       logger.error(error);

--- a/pages/api/update-groups/index.ts
+++ b/pages/api/update-groups/index.ts
@@ -1,11 +1,13 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 
+import { requireSession } from '../../../apiUtils/auth/session';
 import { DatabaseFactory } from '../../../apiUtils/database/DatabaseFactory';
 import { getLogger } from '../../../apiUtils/logger';
 
 const logger = getLogger('updateGroups');
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (!requireSession(req, res)) return;
   const db = DatabaseFactory.getDatabase();
 
   if (req.method === 'GET') {

--- a/pages/api/update-groups/index.ts
+++ b/pages/api/update-groups/index.ts
@@ -1,0 +1,39 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+
+import { DatabaseFactory } from '../../../apiUtils/database/DatabaseFactory';
+import { getLogger } from '../../../apiUtils/logger';
+
+const logger = getLogger('updateGroups');
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const db = DatabaseFactory.getDatabase();
+
+  if (req.method === 'GET') {
+    try {
+      const groups = await db.listUpdateGroups();
+      res.status(200).json({ groups });
+    } catch (error) {
+      logger.error(error);
+      res.status(500).json({ error: 'Failed to list update groups' });
+    }
+    return;
+  }
+
+  if (req.method === 'POST') {
+    const name = typeof req.body?.name === 'string' ? req.body.name.trim() : '';
+    if (!name) {
+      res.status(400).json({ error: 'Missing or empty `name`' });
+      return;
+    }
+    try {
+      const group = await db.createUpdateGroup(name);
+      res.status(201).json({ group });
+    } catch (error) {
+      logger.error(error);
+      res.status(500).json({ error: 'Failed to create update group' });
+    }
+    return;
+  }
+
+  res.status(405).json({ error: 'Method not allowed' });
+}

--- a/pages/api/upload.ts
+++ b/pages/api/upload.ts
@@ -3,6 +3,7 @@ import fs from 'fs';
 import moment from 'moment';
 import { NextApiRequest, NextApiResponse } from 'next';
 
+import { verifySession } from '../../apiUtils/auth/session';
 import { DatabaseFactory } from '../../apiUtils/database/DatabaseFactory';
 import { StorageFactory } from '../../apiUtils/storage/StorageFactory';
 
@@ -33,13 +34,16 @@ export default async function uploadHandler(req: NextApiRequest, res: NextApiRes
     const commitMessage = fields.commitMessage?.[0] || 'No message provided';
     const updateGroupName = fields.updateGroup?.[0];
 
-    if (!uploadKey || !file || !runtimeVersion || !commitHash) {
-      res.status(400).json({ error: 'Missing upload key, file, runtime version or commit hash' });
+    if (!file || !runtimeVersion || !commitHash) {
+      res.status(400).json({ error: 'Missing file, runtime version or commit hash' });
       return;
     }
 
-    if (process.env.UPLOAD_KEY !== uploadKey) {
-      res.status(400).json({ error: 'Upload failed: wrong upload key' });
+    // Authorize: dashboard session OR matching UPLOAD_KEY (for CI/CD).
+    const sessionOk = verifySession(req);
+    const uploadKeyOk = !!uploadKey && process.env.UPLOAD_KEY === uploadKey;
+    if (!sessionOk && !uploadKeyOk) {
+      res.status(401).json({ error: 'Authentication required: provide a session or upload key' });
       return;
     }
 

--- a/pages/api/upload.ts
+++ b/pages/api/upload.ts
@@ -31,6 +31,7 @@ export default async function uploadHandler(req: NextApiRequest, res: NextApiRes
     const runtimeVersion = fields.runtimeVersion?.[0];
     const commitHash = fields.commitHash?.[0];
     const commitMessage = fields.commitMessage?.[0] || 'No message provided';
+    const updateGroupName = fields.updateGroup?.[0];
 
     if (!uploadKey || !file || !runtimeVersion || !commitHash) {
       res.status(400).json({ error: 'Missing upload key, file, runtime version or commit hash' });
@@ -42,11 +43,22 @@ export default async function uploadHandler(req: NextApiRequest, res: NextApiRes
       return;
     }
 
+    const database = DatabaseFactory.getDatabase();
+    let updateGroup;
+    if (updateGroupName) {
+      updateGroup = await database.getUpdateGroupByName(updateGroupName);
+      if (!updateGroup) {
+        res.status(400).json({ error: `Unknown update group: ${updateGroupName}` });
+        return;
+      }
+    } else {
+      updateGroup = await database.getDefaultUpdateGroup();
+    }
+
     const storage = StorageFactory.getStorage();
     const timestamp = moment().utc().format('YYYYMMDDHHmmss');
     const updatePath = `updates/${runtimeVersion}`;
 
-    // Store the zipped file as is
     const zipContent = fs.readFileSync(file.filepath);
     const zipFolder = new AdmZip(file.filepath);
     const metadataJsonFile = await ZipHelper.getFileFromZip(zipFolder, 'metadata.json');
@@ -56,13 +68,14 @@ export default async function uploadHandler(req: NextApiRequest, res: NextApiRes
 
     const path = await storage.uploadFile(`${updatePath}/${timestamp}.zip`, zipContent);
 
-    await DatabaseFactory.getDatabase().createRelease({
+    await database.createRelease({
       path,
       runtimeVersion,
       timestamp: moment().utc().toString(),
       commitHash,
       commitMessage,
       updateId,
+      updateGroupId: updateGroup.id,
     });
 
     res.status(200).json({ success: true, path });

--- a/pages/api/upload.ts
+++ b/pages/api/upload.ts
@@ -82,7 +82,7 @@ export default async function uploadHandler(req: NextApiRequest, res: NextApiRes
       updateGroupId: updateGroup.id,
     });
 
-    res.status(200).json({ success: true, path });
+    res.status(200).json({ success: true, path, updateId, commitHash });
   } catch (error) {
     console.error('Upload error:', error);
     res.status(500).json({ error: 'Upload failed' });

--- a/pages/releases.tsx
+++ b/pages/releases.tsx
@@ -20,6 +20,12 @@ import {
   AlertDialogFooter,
   Flex,
   Tooltip,
+  Badge,
+  FormControl,
+  FormLabel,
+  Input,
+  Select,
+  VStack,
 } from '@chakra-ui/react';
 import moment from 'moment';
 import { useEffect, useRef, useState } from 'react';
@@ -36,6 +42,8 @@ interface Release {
   size: number;
   commitHash: string | null;
   commitMessage: string | null;
+  updateGroupId?: string;
+  updateGroupName?: string;
 }
 
 export default function ReleasesPage() {
@@ -46,9 +54,61 @@ export default function ReleasesPage() {
   const [selectedRelease, setSelectedRelease] = useState<Release | null>(null);
   const cancelRef = useRef<HTMLButtonElement>(null);
 
+  // Upload form state
+  const [uploadKey, setUploadKey] = useState('');
+  const [runtimeVersionInput, setRuntimeVersionInput] = useState('');
+  const [commitHashInput, setCommitHashInput] = useState('');
+  const [commitMessageInput, setCommitMessageInput] = useState('');
+  const [uploadFile, setUploadFile] = useState<File | null>(null);
+  const [uploading, setUploading] = useState(false);
+
+  // Update groups state
+  const [updateGroups, setUpdateGroups] = useState<
+    { id: string; name: string; isDefault: boolean }[]
+  >([]);
+  const [selectedGroupName, setSelectedGroupName] = useState<string>('');
+
   useEffect(() => {
     fetchReleases();
+    fetch('/api/update-groups')
+      .then((r) => r.json())
+      .then((data) => {
+        setUpdateGroups(data.groups);
+        const def = data.groups.find((g: { isDefault: boolean }) => g.isDefault);
+        if (def) setSelectedGroupName(def.name);
+      });
   }, []);
+
+  const handleUpload = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!uploadFile) return;
+    setUploading(true);
+    try {
+      const formData = new FormData();
+      formData.append('uploadKey', uploadKey);
+      formData.append('runtimeVersion', runtimeVersionInput);
+      formData.append('commitHash', commitHashInput);
+      formData.append('commitMessage', commitMessageInput);
+      formData.append('updateGroup', selectedGroupName);
+      formData.append('file', uploadFile);
+      const response = await fetch('/api/upload', { method: 'POST', body: formData });
+      if (!response.ok) {
+        const data = await response.json();
+        throw new Error(data.error || 'Upload failed');
+      }
+      showToast('Upload successful', 'success');
+      setUploadKey('');
+      setRuntimeVersionInput('');
+      setCommitHashInput('');
+      setCommitMessageInput('');
+      setUploadFile(null);
+      fetchReleases();
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : 'Upload failed', 'error');
+    } finally {
+      setUploading(false);
+    }
+  };
 
   const fetchReleases = async () => {
     try {
@@ -82,6 +142,87 @@ export default function ReleasesPage() {
               />
             </HStack>
 
+            <Box
+              as="form"
+              onSubmit={handleUpload}
+              mt={6}
+              mb={8}
+              p={6}
+              borderWidth={1}
+              borderRadius="md"
+              maxW="lg"
+            >
+              <Heading size="sm" mb={4}>
+                Upload Release
+              </Heading>
+              <VStack spacing={3} align="stretch">
+                <FormControl isRequired>
+                  <FormLabel>Upload Key</FormLabel>
+                  <Input
+                    type="password"
+                    value={uploadKey}
+                    onChange={(e) => setUploadKey(e.target.value)}
+                    placeholder="Upload key"
+                  />
+                </FormControl>
+                <FormControl isRequired>
+                  <FormLabel>Runtime Version</FormLabel>
+                  <Input
+                    value={runtimeVersionInput}
+                    onChange={(e) => setRuntimeVersionInput(e.target.value)}
+                    placeholder="e.g. 1.0.0"
+                  />
+                </FormControl>
+                <FormControl isRequired>
+                  <FormLabel>Commit Hash</FormLabel>
+                  <Input
+                    value={commitHashInput}
+                    onChange={(e) => setCommitHashInput(e.target.value)}
+                    placeholder="e.g. abc1234"
+                  />
+                </FormControl>
+                <FormControl>
+                  <FormLabel>Commit Message</FormLabel>
+                  <Input
+                    value={commitMessageInput}
+                    onChange={(e) => setCommitMessageInput(e.target.value)}
+                    placeholder="Optional commit message"
+                  />
+                </FormControl>
+                <FormControl isRequired>
+                  <FormLabel>Update group</FormLabel>
+                  <Select
+                    value={selectedGroupName}
+                    onChange={(e) => setSelectedGroupName(e.target.value)}
+                  >
+                    {updateGroups.map((g) => (
+                      <option key={g.id} value={g.name}>
+                        {g.name}
+                        {g.isDefault ? ' (default)' : ''}
+                      </option>
+                    ))}
+                  </Select>
+                </FormControl>
+                <FormControl isRequired>
+                  <FormLabel>Bundle file</FormLabel>
+                  <Input
+                    type="file"
+                    accept=".zip,.tar,.gz"
+                    onChange={(e) => setUploadFile(e.target.files?.[0] ?? null)}
+                    p={1}
+                  />
+                </FormControl>
+                <Button
+                  type="submit"
+                  colorScheme="blue"
+                  isLoading={uploading}
+                  loadingText="Uploading..."
+                >
+                  Upload
+                </Button>
+              </VStack>
+            </Box>
+
             {loading && <Text>Loading...</Text>}
             {error && <Text color="red.500">{error}</Text>}
 
@@ -91,6 +232,7 @@ export default function ReleasesPage() {
                   <Tr>
                     <Th>Name</Th>
                     <Th>Runtime Version</Th>
+                    <Th>Update Group</Th>
                     <Th>Commit Hash</Th>
                     <Th>Commit Message</Th>
                     <Th>Timestamp (UTC)</Th>
@@ -107,6 +249,17 @@ export default function ReleasesPage() {
                       <Tr key={index}>
                         <Td>{release.path}</Td>
                         <Td>{release.runtimeVersion}</Td>
+                        <Td>
+                          {release.updateGroupName && (
+                            <Badge
+                              colorScheme={
+                                release.updateGroupName === 'production' ? 'green' : 'purple'
+                              }
+                            >
+                              {release.updateGroupName}
+                            </Badge>
+                          )}
+                        </Td>
                         <Td>
                           <Tooltip label={release.commitHash}>
                             <Text isTruncated w="10rem">
@@ -138,12 +291,14 @@ export default function ReleasesPage() {
                               onClick={async () => {
                                 setIsOpen(true);
                                 setSelectedRelease(release);
-                              }}>
+                              }}
+                            >
                               <AlertDialog
                                 isOpen={isOpen}
                                 leastDestructiveRef={cancelRef}
                                 onClose={() => setIsOpen(false)}
-                                isCentered>
+                                isCentered
+                              >
                                 <AlertDialogOverlay>
                                   <AlertDialogContent>
                                     <AlertDialogHeader fontSize="lg" fontWeight="bold">
@@ -157,7 +312,8 @@ export default function ReleasesPage() {
                                         colorScheme="green"
                                         mt={4}
                                         padding={4}
-                                        className="w-full">
+                                        className="w-full"
+                                      >
                                         <Text fontSize="sm">
                                           Commit Hash: {selectedRelease?.commitHash}
                                         </Text>
@@ -198,7 +354,8 @@ export default function ReleasesPage() {
                                           fetchReleases();
                                           setIsOpen(false);
                                         }}
-                                        ml={3}>
+                                        ml={3}
+                                      >
                                         Rollback
                                       </Button>
                                     </AlertDialogFooter>

--- a/pages/releases.tsx
+++ b/pages/releases.tsx
@@ -68,6 +68,9 @@ export default function ReleasesPage() {
   >([]);
   const [selectedGroupName, setSelectedGroupName] = useState<string>('');
 
+  // Filter state for release table
+  const [filterGroupName, setFilterGroupName] = useState<string>(''); // '' = all groups
+
   useEffect(() => {
     fetchReleases();
     fetch('/api/update-groups')
@@ -224,144 +227,167 @@ export default function ReleasesPage() {
             {error && <Text color="red.500">{error}</Text>}
 
             {!loading && !error && (
-              <Table variant="simple">
-                <Thead>
-                  <Tr>
-                    <Th>Name</Th>
-                    <Th>Runtime Version</Th>
-                    <Th>Update Group</Th>
-                    <Th>Commit Hash</Th>
-                    <Th>Commit Message</Th>
-                    <Th>Timestamp (UTC)</Th>
-                    <Th>File Size</Th>
-                    <Th>Actions</Th>
-                  </Tr>
-                </Thead>
-                <Tbody>
-                  {releases
-                    .sort(
-                      (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
-                    )
-                    .map((release, index) => (
-                      <Tr key={index}>
-                        <Td>{release.path}</Td>
-                        <Td>{release.runtimeVersion}</Td>
-                        <Td>
-                          {release.updateGroupName && (
-                            <Badge
-                              colorScheme={
-                                release.updateGroupName === 'production' ? 'green' : 'purple'
-                              }>
-                              {release.updateGroupName}
-                            </Badge>
-                          )}
-                        </Td>
-                        <Td>
-                          <Tooltip label={release.commitHash}>
-                            <Text isTruncated w="10rem">
-                              {release.commitHash}
-                            </Text>
-                          </Tooltip>
-                        </Td>
-                        <Td>
-                          <Tooltip label={release.commitMessage}>
-                            <Text isTruncated w="10rem">
-                              {release.commitMessage}
-                            </Text>
-                          </Tooltip>
-                        </Td>
-                        <Td className="min-w-[14rem]">
-                          {moment(release.timestamp).utc().format('MMM, Do  HH:mm')}
-                        </Td>
-                        <Td>{formatFileSize(release.size)}</Td>
-                        <Td justifyItems="center">
-                          {index === 0 ? (
-                            <Tag size="lg" colorScheme="green">
-                              Active Release
-                            </Tag>
-                          ) : (
-                            <Button
-                              variant="solid"
-                              colorScheme="orange"
-                              size="sm"
-                              onClick={async () => {
-                                setIsOpen(true);
-                                setSelectedRelease(release);
-                              }}>
-                              <AlertDialog
-                                isOpen={isOpen}
-                                leastDestructiveRef={cancelRef}
-                                onClose={() => setIsOpen(false)}
-                                isCentered>
-                                <AlertDialogOverlay>
-                                  <AlertDialogContent>
-                                    <AlertDialogHeader fontSize="lg" fontWeight="bold">
-                                      Rollback Release
-                                    </AlertDialogHeader>
-
-                                    <AlertDialogBody>
-                                      Are you sure you want to rollback to this release?
-                                      <Tag
-                                        size="lg"
-                                        colorScheme="green"
-                                        mt={4}
-                                        padding={4}
-                                        className="w-full">
-                                        <Text fontSize="sm">
-                                          Commit Hash: {selectedRelease?.commitHash}
-                                        </Text>
-                                      </Tag>
-                                      <Tag size="lg" colorScheme="orange" mt={4} padding={4}>
-                                        <Text fontSize="sm">
-                                          This will promote this release to be the active release
-                                          with a new timestamp.
-                                        </Text>
-                                      </Tag>
-                                    </AlertDialogBody>
-
-                                    <AlertDialogFooter>
-                                      <Button ref={cancelRef} onClick={() => setIsOpen(false)}>
-                                        Cancel
-                                      </Button>
-                                      <Button
-                                        colorScheme="red"
-                                        onClick={async () => {
-                                          const response = await fetch('/api/rollback', {
-                                            method: 'POST',
-                                            headers: {
-                                              'Content-Type': 'application/json',
-                                            },
-                                            body: JSON.stringify({
-                                              path: selectedRelease?.path,
-                                              runtimeVersion: selectedRelease?.runtimeVersion,
-                                              commitHash: selectedRelease?.commitHash,
-                                              commitMessage: selectedRelease?.commitMessage,
-                                            }),
-                                          });
-
-                                          if (!response.ok) {
-                                            throw new Error('Rollback failed');
-                                          }
-
-                                          showToast('Rollback successful', 'success');
-                                          fetchReleases();
-                                          setIsOpen(false);
-                                        }}
-                                        ml={3}>
-                                        Rollback
-                                      </Button>
-                                    </AlertDialogFooter>
-                                  </AlertDialogContent>
-                                </AlertDialogOverlay>
-                              </AlertDialog>
-                              Rollback to this release
-                            </Button>
-                          )}
-                        </Td>
-                      </Tr>
+              <>
+                <HStack mb={4}>
+                  <FormLabel mb={0}>Filter by group:</FormLabel>
+                  <Select
+                    width="auto"
+                    value={filterGroupName}
+                    onChange={(e) => setFilterGroupName(e.target.value)}>
+                    <option value="">All groups</option>
+                    {updateGroups.map((g) => (
+                      <option key={g.id} value={g.name}>
+                        {g.name}
+                        {g.isDefault ? ' (default)' : ''}
+                      </option>
                     ))}
-                </Tbody>
-              </Table>
+                  </Select>
+                </HStack>
+                <Table variant="simple">
+                  <Thead>
+                    <Tr>
+                      <Th>Name</Th>
+                      <Th>Runtime Version</Th>
+                      <Th>Update Group</Th>
+                      <Th>Commit Hash</Th>
+                      <Th>Commit Message</Th>
+                      <Th>Timestamp (UTC)</Th>
+                      <Th>File Size</Th>
+                      <Th>Actions</Th>
+                    </Tr>
+                  </Thead>
+                  <Tbody>
+                    {(() => {
+                      const visibleReleases = filterGroupName
+                        ? releases.filter((r) => r.updateGroupName === filterGroupName)
+                        : releases;
+                      return visibleReleases
+                        .sort(
+                          (a, b) =>
+                            new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
+                        )
+                        .map((release, index) => (
+                          <Tr key={index}>
+                            <Td>{release.path}</Td>
+                            <Td>{release.runtimeVersion}</Td>
+                            <Td>
+                              {release.updateGroupName && (
+                                <Badge
+                                  colorScheme={
+                                    release.updateGroupName === 'production' ? 'green' : 'purple'
+                                  }>
+                                  {release.updateGroupName}
+                                </Badge>
+                              )}
+                            </Td>
+                            <Td>
+                              <Tooltip label={release.commitHash}>
+                                <Text isTruncated w="10rem">
+                                  {release.commitHash}
+                                </Text>
+                              </Tooltip>
+                            </Td>
+                            <Td>
+                              <Tooltip label={release.commitMessage}>
+                                <Text isTruncated w="10rem">
+                                  {release.commitMessage}
+                                </Text>
+                              </Tooltip>
+                            </Td>
+                            <Td className="min-w-[14rem]">
+                              {moment(release.timestamp).utc().format('MMM, Do  HH:mm')}
+                            </Td>
+                            <Td>{formatFileSize(release.size)}</Td>
+                            <Td justifyItems="center">
+                              {index === 0 ? (
+                                <Tag size="lg" colorScheme="green">
+                                  Active Release
+                                </Tag>
+                              ) : (
+                                <Button
+                                  variant="solid"
+                                  colorScheme="orange"
+                                  size="sm"
+                                  onClick={async () => {
+                                    setIsOpen(true);
+                                    setSelectedRelease(release);
+                                  }}>
+                                  <AlertDialog
+                                    isOpen={isOpen}
+                                    leastDestructiveRef={cancelRef}
+                                    onClose={() => setIsOpen(false)}
+                                    isCentered>
+                                    <AlertDialogOverlay>
+                                      <AlertDialogContent>
+                                        <AlertDialogHeader fontSize="lg" fontWeight="bold">
+                                          Rollback Release
+                                        </AlertDialogHeader>
+
+                                        <AlertDialogBody>
+                                          Are you sure you want to rollback to this release?
+                                          <Tag
+                                            size="lg"
+                                            colorScheme="green"
+                                            mt={4}
+                                            padding={4}
+                                            className="w-full">
+                                            <Text fontSize="sm">
+                                              Commit Hash: {selectedRelease?.commitHash}
+                                            </Text>
+                                          </Tag>
+                                          <Tag size="lg" colorScheme="orange" mt={4} padding={4}>
+                                            <Text fontSize="sm">
+                                              This will promote this release to be the active
+                                              release with a new timestamp.
+                                            </Text>
+                                          </Tag>
+                                        </AlertDialogBody>
+
+                                        <AlertDialogFooter>
+                                          <Button ref={cancelRef} onClick={() => setIsOpen(false)}>
+                                            Cancel
+                                          </Button>
+                                          <Button
+                                            colorScheme="red"
+                                            onClick={async () => {
+                                              const response = await fetch('/api/rollback', {
+                                                method: 'POST',
+                                                headers: {
+                                                  'Content-Type': 'application/json',
+                                                },
+                                                body: JSON.stringify({
+                                                  path: selectedRelease?.path,
+                                                  runtimeVersion: selectedRelease?.runtimeVersion,
+                                                  commitHash: selectedRelease?.commitHash,
+                                                  commitMessage: selectedRelease?.commitMessage,
+                                                }),
+                                              });
+
+                                              if (!response.ok) {
+                                                throw new Error('Rollback failed');
+                                              }
+
+                                              showToast('Rollback successful', 'success');
+                                              fetchReleases();
+                                              setIsOpen(false);
+                                            }}
+                                            ml={3}>
+                                            Rollback
+                                          </Button>
+                                        </AlertDialogFooter>
+                                      </AlertDialogContent>
+                                    </AlertDialogOverlay>
+                                  </AlertDialog>
+                                  Rollback to this release
+                                </Button>
+                              )}
+                            </Td>
+                          </Tr>
+                        ));
+                    })()}
+                  </Tbody>
+                </Table>
+              </>
             )}
           </Flex>
         </Box>

--- a/pages/releases.tsx
+++ b/pages/releases.tsx
@@ -150,8 +150,7 @@ export default function ReleasesPage() {
               p={6}
               borderWidth={1}
               borderRadius="md"
-              maxW="lg"
-            >
+              maxW="lg">
               <Heading size="sm" mb={4}>
                 Upload Release
               </Heading>
@@ -193,8 +192,7 @@ export default function ReleasesPage() {
                   <FormLabel>Update group</FormLabel>
                   <Select
                     value={selectedGroupName}
-                    onChange={(e) => setSelectedGroupName(e.target.value)}
-                  >
+                    onChange={(e) => setSelectedGroupName(e.target.value)}>
                     {updateGroups.map((g) => (
                       <option key={g.id} value={g.name}>
                         {g.name}
@@ -216,8 +214,7 @@ export default function ReleasesPage() {
                   type="submit"
                   colorScheme="blue"
                   isLoading={uploading}
-                  loadingText="Uploading..."
-                >
+                  loadingText="Uploading...">
                   Upload
                 </Button>
               </VStack>
@@ -254,8 +251,7 @@ export default function ReleasesPage() {
                             <Badge
                               colorScheme={
                                 release.updateGroupName === 'production' ? 'green' : 'purple'
-                              }
-                            >
+                              }>
                               {release.updateGroupName}
                             </Badge>
                           )}
@@ -291,14 +287,12 @@ export default function ReleasesPage() {
                               onClick={async () => {
                                 setIsOpen(true);
                                 setSelectedRelease(release);
-                              }}
-                            >
+                              }}>
                               <AlertDialog
                                 isOpen={isOpen}
                                 leastDestructiveRef={cancelRef}
                                 onClose={() => setIsOpen(false)}
-                                isCentered
-                              >
+                                isCentered>
                                 <AlertDialogOverlay>
                                   <AlertDialogContent>
                                     <AlertDialogHeader fontSize="lg" fontWeight="bold">
@@ -312,8 +306,7 @@ export default function ReleasesPage() {
                                         colorScheme="green"
                                         mt={4}
                                         padding={4}
-                                        className="w-full"
-                                      >
+                                        className="w-full">
                                         <Text fontSize="sm">
                                           Commit Hash: {selectedRelease?.commitHash}
                                         </Text>
@@ -354,8 +347,7 @@ export default function ReleasesPage() {
                                           fetchReleases();
                                           setIsOpen(false);
                                         }}
-                                        ml={3}
-                                      >
+                                        ml={3}>
                                         Rollback
                                       </Button>
                                     </AlertDialogFooter>

--- a/pages/releases.tsx
+++ b/pages/releases.tsx
@@ -21,11 +21,8 @@ import {
   Flex,
   Tooltip,
   Badge,
-  FormControl,
   FormLabel,
-  Input,
   Select,
-  VStack,
 } from '@chakra-ui/react';
 import moment from 'moment';
 import { useEffect, useRef, useState } from 'react';
@@ -54,66 +51,18 @@ export default function ReleasesPage() {
   const [selectedRelease, setSelectedRelease] = useState<Release | null>(null);
   const cancelRef = useRef<HTMLButtonElement>(null);
 
-  // Upload form state
-  const [uploadKey, setUploadKey] = useState('');
-  const [runtimeVersionInput, setRuntimeVersionInput] = useState('');
-  const [commitHashInput, setCommitHashInput] = useState('');
-  const [commitMessageInput, setCommitMessageInput] = useState('');
-  const [uploadFile, setUploadFile] = useState<File | null>(null);
-  const [uploading, setUploading] = useState(false);
-
-  // Update groups state
   const [updateGroups, setUpdateGroups] = useState<
     { id: string; name: string; isDefault: boolean }[]
   >([]);
-  const [selectedGroupName, setSelectedGroupName] = useState<string>('');
-
-  // Filter state for release table
   const [filterGroupName, setFilterGroupName] = useState<string>(''); // '' = all groups
 
   useEffect(() => {
     fetchReleases();
     fetch('/api/update-groups')
       .then((r) => r.json())
-      .then((data) => {
-        const groups = data.groups ?? [];
-        setUpdateGroups(groups);
-        const def = groups.find((g: { isDefault: boolean }) => g.isDefault);
-        if (def) setSelectedGroupName(def.name);
-      })
+      .then((data) => setUpdateGroups(data.groups ?? []))
       .catch(() => setUpdateGroups([]));
   }, []);
-
-  const handleUpload = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!uploadFile) return;
-    setUploading(true);
-    try {
-      const formData = new FormData();
-      formData.append('uploadKey', uploadKey);
-      formData.append('runtimeVersion', runtimeVersionInput);
-      formData.append('commitHash', commitHashInput);
-      formData.append('commitMessage', commitMessageInput);
-      formData.append('updateGroup', selectedGroupName);
-      formData.append('file', uploadFile);
-      const response = await fetch('/api/upload', { method: 'POST', body: formData });
-      if (!response.ok) {
-        const data = await response.json();
-        throw new Error(data.error || 'Upload failed');
-      }
-      showToast('Upload successful', 'success');
-      setUploadKey('');
-      setRuntimeVersionInput('');
-      setCommitHashInput('');
-      setCommitMessageInput('');
-      setUploadFile(null);
-      fetchReleases();
-    } catch (err) {
-      showToast(err instanceof Error ? err.message : 'Upload failed', 'error');
-    } finally {
-      setUploading(false);
-    }
-  };
 
   const fetchReleases = async () => {
     try {
@@ -146,84 +95,6 @@ export default function ReleasesPage() {
                 icon={<SlRefresh />}
               />
             </HStack>
-
-            <Box
-              as="form"
-              onSubmit={handleUpload}
-              mt={6}
-              mb={8}
-              p={6}
-              borderWidth={1}
-              borderRadius="md"
-              maxW="lg">
-              <Heading size="sm" mb={4}>
-                Upload Release
-              </Heading>
-              <VStack spacing={3} align="stretch">
-                <FormControl isRequired>
-                  <FormLabel>Upload Key</FormLabel>
-                  <Input
-                    type="password"
-                    value={uploadKey}
-                    onChange={(e) => setUploadKey(e.target.value)}
-                    placeholder="Upload key"
-                  />
-                </FormControl>
-                <FormControl isRequired>
-                  <FormLabel>Runtime Version</FormLabel>
-                  <Input
-                    value={runtimeVersionInput}
-                    onChange={(e) => setRuntimeVersionInput(e.target.value)}
-                    placeholder="e.g. 1.0.0"
-                  />
-                </FormControl>
-                <FormControl isRequired>
-                  <FormLabel>Commit Hash</FormLabel>
-                  <Input
-                    value={commitHashInput}
-                    onChange={(e) => setCommitHashInput(e.target.value)}
-                    placeholder="e.g. abc1234"
-                  />
-                </FormControl>
-                <FormControl>
-                  <FormLabel>Commit Message</FormLabel>
-                  <Input
-                    value={commitMessageInput}
-                    onChange={(e) => setCommitMessageInput(e.target.value)}
-                    placeholder="Optional commit message"
-                  />
-                </FormControl>
-                <FormControl isRequired>
-                  <FormLabel>Update group</FormLabel>
-                  <Select
-                    value={selectedGroupName}
-                    onChange={(e) => setSelectedGroupName(e.target.value)}>
-                    {updateGroups.map((g) => (
-                      <option key={g.id} value={g.name}>
-                        {g.name}
-                        {g.isDefault ? ' (default)' : ''}
-                      </option>
-                    ))}
-                  </Select>
-                </FormControl>
-                <FormControl isRequired>
-                  <FormLabel>Bundle file</FormLabel>
-                  <Input
-                    type="file"
-                    accept=".zip,.tar,.gz"
-                    onChange={(e) => setUploadFile(e.target.files?.[0] ?? null)}
-                    p={1}
-                  />
-                </FormControl>
-                <Button
-                  type="submit"
-                  colorScheme="blue"
-                  isLoading={uploading}
-                  loadingText="Uploading...">
-                  Upload
-                </Button>
-              </VStack>
-            </Box>
 
             {loading && <Text>Loading...</Text>}
             {error && <Text color="red.500">{error}</Text>}

--- a/pages/releases.tsx
+++ b/pages/releases.tsx
@@ -76,10 +76,12 @@ export default function ReleasesPage() {
     fetch('/api/update-groups')
       .then((r) => r.json())
       .then((data) => {
-        setUpdateGroups(data.groups);
-        const def = data.groups.find((g: { isDefault: boolean }) => g.isDefault);
+        const groups = data.groups ?? [];
+        setUpdateGroups(groups);
+        const def = groups.find((g: { isDefault: boolean }) => g.isDefault);
         if (def) setSelectedGroupName(def.name);
-      });
+      })
+      .catch(() => setUpdateGroups([]));
   }, []);
 
   const handleUpload = async (e: React.FormEvent) => {

--- a/pages/update-groups.tsx
+++ b/pages/update-groups.tsx
@@ -24,7 +24,7 @@ type UpdateGroup = {
   createdAt: string;
 };
 
-type Member = { updateGroupId: string; userId: string; createdAt: string };
+type Member = { updateGroupId: string; userId: string; label?: string; createdAt: string };
 
 export default function UpdateGroupsPage() {
   const [groups, setGroups] = useState<UpdateGroup[] | null>(null);
@@ -32,6 +32,7 @@ export default function UpdateGroupsPage() {
   const [selected, setSelected] = useState<UpdateGroup | null>(null);
   const [members, setMembers] = useState<Member[]>([]);
   const [newMemberId, setNewMemberId] = useState('');
+  const [newMemberLabel, setNewMemberLabel] = useState('');
 
   async function refreshGroups() {
     const res = await fetch('/api/update-groups');
@@ -85,13 +86,17 @@ export default function UpdateGroupsPage() {
     const res = await fetch(`/api/update-groups/${selected.id}/members`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ userId: newMemberId.trim() }),
+      body: JSON.stringify({
+        userId: newMemberId.trim(),
+        label: newMemberLabel.trim() || undefined,
+      }),
     });
     if (!res.ok) {
       showToast('Failed to add member', 'error');
       return;
     }
     setNewMemberId('');
+    setNewMemberLabel('');
     refreshMembers(selected);
   }
 
@@ -180,7 +185,14 @@ export default function UpdateGroupsPage() {
                         {members.map((m) => (
                           <ListItem key={m.userId} p={2} borderWidth="1px" borderRadius="md">
                             <HStack justify="space-between">
-                              <Text>{m.userId}</Text>
+                              <VStack align="start" spacing={0}>
+                                {m.label && <Text fontWeight="medium">{m.label}</Text>}
+                                <Text
+                                  fontSize={m.label ? 'sm' : 'md'}
+                                  color={m.label ? 'gray.600' : 'inherit'}>
+                                  {m.userId}
+                                </Text>
+                              </VStack>
                               <Button
                                 size="xs"
                                 colorScheme="red"
@@ -197,6 +209,11 @@ export default function UpdateGroupsPage() {
                         placeholder="User id"
                         value={newMemberId}
                         onChange={(e) => setNewMemberId(e.target.value)}
+                      />
+                      <Input
+                        placeholder="Label (optional, e.g. name or email)"
+                        value={newMemberLabel}
+                        onChange={(e) => setNewMemberLabel(e.target.value)}
                       />
                       <Button onClick={addMember}>Add</Button>
                     </HStack>

--- a/pages/update-groups.tsx
+++ b/pages/update-groups.tsx
@@ -1,0 +1,212 @@
+import { useEffect, useState } from 'react';
+import {
+  Box,
+  Button,
+  Flex,
+  Heading,
+  HStack,
+  Input,
+  List,
+  ListItem,
+  Spinner,
+  Text,
+  VStack,
+} from '@chakra-ui/react';
+
+import Layout from '../components/Layout';
+import ProtectedRoute from '../components/ProtectedRoute';
+import { showToast } from '../components/toast';
+
+type UpdateGroup = {
+  id: string;
+  name: string;
+  isDefault: boolean;
+  createdAt: string;
+};
+
+type Member = { updateGroupId: string; userId: string; createdAt: string };
+
+export default function UpdateGroupsPage() {
+  const [groups, setGroups] = useState<UpdateGroup[] | null>(null);
+  const [newName, setNewName] = useState('');
+  const [selected, setSelected] = useState<UpdateGroup | null>(null);
+  const [members, setMembers] = useState<Member[]>([]);
+  const [newMemberId, setNewMemberId] = useState('');
+
+  async function refreshGroups() {
+    const res = await fetch('/api/update-groups');
+    const json = await res.json();
+    setGroups(json.groups);
+  }
+
+  async function refreshMembers(group: UpdateGroup) {
+    const res = await fetch(`/api/update-groups/${group.id}/members`);
+    const json = await res.json();
+    setMembers(json.members);
+  }
+
+  useEffect(() => {
+    refreshGroups();
+  }, []);
+  useEffect(() => {
+    if (selected) refreshMembers(selected);
+  }, [selected]);
+
+  async function createGroup() {
+    if (!newName.trim()) return;
+    const res = await fetch('/api/update-groups', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ name: newName.trim() }),
+    });
+    if (!res.ok) {
+      showToast('Failed to create group', 'error');
+      return;
+    }
+    setNewName('');
+    showToast('Group created', 'success');
+    refreshGroups();
+  }
+
+  async function deleteGroup(group: UpdateGroup) {
+    if (!confirm(`Delete group "${group.name}"?`)) return;
+    const res = await fetch(`/api/update-groups/${group.id}`, { method: 'DELETE' });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      showToast(err.error ?? 'Failed to delete group', 'error');
+      return;
+    }
+    if (selected?.id === group.id) setSelected(null);
+    refreshGroups();
+  }
+
+  async function addMember() {
+    if (!selected || !newMemberId.trim()) return;
+    const res = await fetch(`/api/update-groups/${selected.id}/members`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ userId: newMemberId.trim() }),
+    });
+    if (!res.ok) {
+      showToast('Failed to add member', 'error');
+      return;
+    }
+    setNewMemberId('');
+    refreshMembers(selected);
+  }
+
+  async function removeMember(userId: string) {
+    if (!selected) return;
+    const res = await fetch(
+      `/api/update-groups/${selected.id}/members?userId=${encodeURIComponent(userId)}`,
+      { method: 'DELETE' }
+    );
+    if (!res.ok) {
+      showToast('Failed to remove member', 'error');
+      return;
+    }
+    refreshMembers(selected);
+  }
+
+  return (
+    <ProtectedRoute>
+      <Layout>
+        <Heading mb={6}>Update Groups</Heading>
+        <Flex gap={8} align="flex-start">
+          <Box flex="1">
+            <Heading size="md" mb={3}>
+              Groups
+            </Heading>
+            {groups === null ? (
+              <Spinner />
+            ) : (
+              <List spacing={2}>
+                {groups.map((g) => (
+                  <ListItem
+                    key={g.id}
+                    p={3}
+                    borderWidth="1px"
+                    borderRadius="md"
+                    cursor="pointer"
+                    bg={selected?.id === g.id ? 'gray.50' : undefined}
+                    onClick={() => setSelected(g)}>
+                    <HStack justify="space-between">
+                      <Text fontWeight="medium">
+                        {g.name}
+                        {g.isDefault ? ' (default)' : ''}
+                      </Text>
+                      {!g.isDefault && (
+                        <Button
+                          size="xs"
+                          colorScheme="red"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            deleteGroup(g);
+                          }}>
+                          Delete
+                        </Button>
+                      )}
+                    </HStack>
+                  </ListItem>
+                ))}
+              </List>
+            )}
+            <HStack mt={4}>
+              <Input
+                placeholder="New group name"
+                value={newName}
+                onChange={(e) => setNewName(e.target.value)}
+              />
+              <Button onClick={createGroup}>Create</Button>
+            </HStack>
+          </Box>
+
+          <Box flex="1">
+            <Heading size="md" mb={3}>
+              {selected ? `Members of "${selected.name}"` : 'Select a group'}
+            </Heading>
+            {selected && (
+              <VStack align="stretch" spacing={2}>
+                {selected.isDefault ? (
+                  <Text color="gray.600">
+                    The default group has implicit membership — every user is in it.
+                  </Text>
+                ) : (
+                  <>
+                    {members.length === 0 ? (
+                      <Text color="gray.600">No members yet.</Text>
+                    ) : (
+                      <List spacing={2}>
+                        {members.map((m) => (
+                          <ListItem key={m.userId} p={2} borderWidth="1px" borderRadius="md">
+                            <HStack justify="space-between">
+                              <Text>{m.userId}</Text>
+                              <Button
+                                size="xs"
+                                colorScheme="red"
+                                onClick={() => removeMember(m.userId)}>
+                                Remove
+                              </Button>
+                            </HStack>
+                          </ListItem>
+                        ))}
+                      </List>
+                    )}
+                    <HStack>
+                      <Input
+                        placeholder="User id"
+                        value={newMemberId}
+                        onChange={(e) => setNewMemberId(e.target.value)}
+                      />
+                      <Button onClick={addMember}>Add</Button>
+                    </HStack>
+                  </>
+                )}
+              </VStack>
+            )}
+          </Box>
+        </Flex>
+      </Layout>
+    </ProtectedRoute>
+  );
+}

--- a/pages/update-groups.tsx
+++ b/pages/update-groups.tsx
@@ -209,11 +209,17 @@ export default function UpdateGroupsPage() {
                         placeholder="User id"
                         value={newMemberId}
                         onChange={(e) => setNewMemberId(e.target.value)}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter') addMember();
+                        }}
                       />
                       <Input
                         placeholder="Label (optional, e.g. name or email)"
                         value={newMemberLabel}
                         onChange={(e) => setNewMemberLabel(e.target.value)}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter') addMember();
+                        }}
                       />
                       <Button onClick={addMember}>Add</Button>
                     </HStack>

--- a/render.yaml
+++ b/render.yaml
@@ -10,6 +10,7 @@
 # After the first deploy, apply the schema once:
 #   psql <DATABASE_URL> -f containers/database/schema/releases.sql
 #   psql <DATABASE_URL> -f containers/database/schema/tracking.sql
+#   psql <DATABASE_URL> -f containers/database/schema/update_groups.sql
 # (or copy-paste into the Render Postgres web shell)
 
 services:
@@ -32,21 +33,37 @@ services:
       - key: HOST
         sync: false
 
-      # Storage backend. `local` works but Render's filesystem is ephemeral
-      # so uploaded bundles disappear on every deploy. Use `s3`, `gcs`, or
-      # `supabase` for anything you care about. Set the backend-specific
-      # credentials in the dashboard.
+      # Storage backend. Configured for Cloudflare R2 (S3-compatible).
+      # Set the credentials below in the Render dashboard.
       - key: BLOB_STORAGE_TYPE
+        value: s3
+      - key: S3_ACCESS_KEY_ID
         sync: false
+      - key: S3_SECRET_ACCESS_KEY
+        sync: false
+      - key: S3_BUCKET_NAME
+        sync: false
+      # R2 endpoint, e.g. https://<account-id>.r2.cloudflarestorage.com
+      - key: S3_ENDPOINT
+        sync: false
+      # `auto` is correct for R2; only override for real S3.
+      - key: S3_REGION
+        value: auto
 
       - key: DB_TYPE
         value: postgres
 
-      # Admin credentials.
+      # Admin login password. Set manually so you know what to type at /login.
       - key: ADMIN_PASSWORD
         sync: false
+      # Shared secret for CI/CD uploads. Render generates a strong random;
+      # copy it from the dashboard into your CI secrets store.
       - key: UPLOAD_KEY
-        sync: false
+        generateValue: true
+      # HMAC key for the admin session cookie. Rotating invalidates all
+      # current sessions; never needs to be human-readable.
+      - key: SESSION_SECRET
+        generateValue: true
 
       # Code-signing private key (base64). Optional — only required if your
       # Expo client sets expo-expect-signature.

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,84 @@
+# Render Blueprint for xavia-ota.
+# https://render.com/docs/blueprint-spec
+#
+# Provisions a Next.js web service and a managed Postgres database.
+# Database connection details are wired into the web service's env vars
+# automatically via `fromDatabase`. Secrets and storage credentials are
+# marked `sync: false` so Render holds the values out of git — set them
+# in the Render dashboard after the first apply.
+#
+# After the first deploy, apply the schema once:
+#   psql <DATABASE_URL> -f containers/database/schema/releases.sql
+#   psql <DATABASE_URL> -f containers/database/schema/tracking.sql
+# (or copy-paste into the Render Postgres web shell)
+
+services:
+  - type: web
+    name: xavia-ota
+    runtime: node
+    region: frankfurt
+    plan: starter
+    branch: main
+    buildCommand: npm ci && npm run build
+    startCommand: npm start
+    healthCheckPath: /api/manifest?platform=ios&runtime-version=health
+    autoDeploy: true
+    envVars:
+      - key: NODE_VERSION
+        value: '20'
+
+      # App config — set HOST after the service is provisioned so the
+      # manifest can hand clients absolute asset URLs that point back here.
+      - key: HOST
+        sync: false
+
+      # Storage backend. `local` works but Render's filesystem is ephemeral
+      # so uploaded bundles disappear on every deploy. Use `s3`, `gcs`, or
+      # `supabase` for anything you care about. Set the backend-specific
+      # credentials in the dashboard.
+      - key: BLOB_STORAGE_TYPE
+        sync: false
+
+      - key: DB_TYPE
+        value: postgres
+
+      # Admin credentials.
+      - key: ADMIN_PASSWORD
+        sync: false
+      - key: UPLOAD_KEY
+        sync: false
+
+      # Code-signing private key (base64). Optional — only required if your
+      # Expo client sets expo-expect-signature.
+      - key: PRIVATE_KEY_BASE_64
+        sync: false
+
+      # Postgres connection. Wired from the managed database below.
+      - key: POSTGRES_HOST
+        fromDatabase:
+          name: xavia-ota-db
+          property: host
+      - key: POSTGRES_PORT
+        fromDatabase:
+          name: xavia-ota-db
+          property: port
+      - key: POSTGRES_USER
+        fromDatabase:
+          name: xavia-ota-db
+          property: user
+      - key: POSTGRES_PASSWORD
+        fromDatabase:
+          name: xavia-ota-db
+          property: password
+      - key: POSTGRES_DB
+        fromDatabase:
+          name: xavia-ota-db
+          property: database
+
+databases:
+  - name: xavia-ota-db
+    plan: basic-256mb
+    region: frankfurt
+    databaseName: releases_db
+    user: xavia_ota
+    postgresMajorVersion: '16'

--- a/render.yaml
+++ b/render.yaml
@@ -98,4 +98,4 @@ databases:
     region: frankfurt
     databaseName: releases_db
     user: xavia_ota
-    postgresMajorVersion: '16'
+    postgresMajorVersion: '18'

--- a/scripts/build-and-publish-app-release.sh
+++ b/scripts/build-and-publish-app-release.sh
@@ -20,7 +20,7 @@ updateGroup=$4
 
 # Generate a timestamp for the output folder
 timestamp=$(date -u +%Y%m%d%H%M%S)
-outputFolder="../ota-builds/$timestamp"
+outputFolder="./ota-builds/$timestamp"
 
 # Ask the user to confirm the hash, commit message, runtime version, and output folder
 echo "Output Folder: $outputFolder"
@@ -42,13 +42,15 @@ mkdir -p $outputFolder
 # Run expo export with the specified output folder
 npx expo export --output-dir $outputFolder
 
-# Extract expo config property from app.json and save to expoconfig.json
-jq '.expo' app.json > $outputFolder/expoconfig.json
+# Resolve the expo config (works for app.json, app.config.js, or app.config.ts)
+# --type public emits the manifest-shape config, matching what's served to clients.
+npx expo config --type public --json > $outputFolder/expoconfig.json
 
 
-# Zip the output folder
-cd $outputFolder  
-zip -q -r ${timestamp}.zip .
+# Zip the output folder (operate inside it, then return to project root)
+projectRoot=$(pwd)
+cd "$outputFolder"
+zip -q -r "${timestamp}.zip" .
 
 
 # Upload the zip file to the server
@@ -61,7 +63,7 @@ curl -X POST "$serverHost/api/upload" "${uploadArgs[@]}"
 echo ""
 
 echo "Uploaded to $serverHost/api/upload"
-cd ..
+cd "$projectRoot"
 
 # Remove the output folder and zip file
 rm -rf $outputFolder

--- a/scripts/build-and-publish-app-release.sh
+++ b/scripts/build-and-publish-app-release.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
 # Check if the correct number of arguments are provided
-if [ "$#" -ne 3 ]; then
-  echo "Usage: $0 <runtimeVersion> <xavia-ota-url> <upload-key>"
+if [ "$#" -lt 3 ] || [ "$#" -gt 4 ]; then
+  echo "Usage: $0 <runtimeVersion> <xavia-ota-url> <upload-key> [updateGroup]"
+  echo ""
+  echo "  updateGroup is optional; omit to publish to the default group."
   exit 1
 fi
 
@@ -14,6 +16,7 @@ commitMessage=$(git log -1 --pretty=%B)
 runtimeVersion=$1
 serverHost=$2
 uploadKey=$3
+updateGroup=$4
 
 # Generate a timestamp for the output folder
 timestamp=$(date -u +%Y%m%d%H%M%S)
@@ -24,6 +27,7 @@ echo "Output Folder: $outputFolder"
 echo "Runtime Version: $runtimeVersion"
 echo "Commit Hash: $commitHash"
 echo "Commit Message: $commitMessage"
+echo "Update Group: ${updateGroup:-(default)}"
 
 read -p "Do you want to proceed with these values? (y/n): " confirm
 
@@ -48,7 +52,11 @@ zip -q -r ${timestamp}.zip .
 
 
 # Upload the zip file to the server
-curl -X POST $serverHost/api/upload -F "file=@${timestamp}.zip" -F "runtimeVersion=$runtimeVersion" -F "commitHash=$commitHash" -F "commitMessage=$commitMessage" -F "uploadKey=$uploadKey"
+uploadArgs=(-F "file=@${timestamp}.zip" -F "runtimeVersion=$runtimeVersion" -F "commitHash=$commitHash" -F "commitMessage=$commitMessage" -F "uploadKey=$uploadKey")
+if [ -n "$updateGroup" ]; then
+  uploadArgs+=(-F "updateGroup=$updateGroup")
+fi
+curl -X POST "$serverHost/api/upload" "${uploadArgs[@]}"
 
 echo ""
 

--- a/scripts/build-and-publish-app-release.sh
+++ b/scripts/build-and-publish-app-release.sh
@@ -58,11 +58,16 @@ uploadArgs=(-F "file=@${timestamp}.zip" -F "runtimeVersion=$runtimeVersion" -F "
 if [ -n "$updateGroup" ]; then
   uploadArgs+=(-F "updateGroup=$updateGroup")
 fi
-curl -X POST "$serverHost/api/upload" "${uploadArgs[@]}"
+response=$(curl -sS -X POST "$serverHost/api/upload" "${uploadArgs[@]}")
 
 echo ""
-
 echo "Uploaded to $serverHost/api/upload"
+echo "Response: $response"
+
+updateId=$(echo "$response" | jq -r '.updateId // empty')
+if [ -n "$updateId" ]; then
+  echo "Update ID: $updateId"
+fi
 cd "$projectRoot"
 
 # Remove the output folder and zip file

--- a/scripts/dev/Makefile
+++ b/scripts/dev/Makefile
@@ -1,18 +1,24 @@
 .PHONY: dev db check-db
 
+# If .env.local exists at the project root, hand it to docker-compose so it can
+# interpolate POSTGRES_PORT etc. from the same source the app already uses.
+ENV_FILE = .env.local
+COMPOSE_ENV_ARG = $(if $(wildcard $(ENV_FILE)),--env-file $(ENV_FILE),)
+COMPOSE = docker-compose $(COMPOSE_ENV_ARG) -f ./containers/database/docker-compose.yml
+
 # Start both database and Next.js development server
 dev: db check-db
 	next dev -p 3001
 
 # Start Docker Compose in detached mode
 db:
-	cd ./containers/database && docker-compose up -d
+	$(COMPOSE) up -d
 
 # Check if database container is healthy
 check-db:
 	@echo "Waiting for database to be ready..."
-	@until docker-compose -f ./containers/database/docker-compose.yml ps | grep "healthy"; do \
+	@until $(COMPOSE) ps | grep "healthy"; do \
 		echo "Waiting for database..."; \
 		sleep 1; \
 	done
-	@echo "Database is ready!" 
+	@echo "Database is ready!"


### PR DESCRIPTION
## Summary

- `/api/manifest` already scopes releases per user (via `xavia-user-id` in `Expo-Extra-Params` and update-group membership), but `/api/assets` was still resolving "latest release for this runtime version" by listing the storage directory. That meant a manifest pointing at beta release `B1` could get its asset URLs answered with prod release `P2`'s bytes the moment `P2` was published — manifest+assets out of sync, and no group authorization on the assets path at all.
- Manifest now embeds the resolved release's id into each asset URL (`?asset=…&releaseId=…&runtimeVersion=…&platform=…`). `/api/assets` reads `releaseId`, looks up the release in the database, validates `runtimeVersion`, and serves from that bundle's path. The "latest by storage timestamp" code path is gone.
- While I was in there: consolidated the manifest endpoint's three DB fetches for the same release into one (`getLatestReleaseForUser` at the top is now the single source of truth). Dropped `UpdateHelper.getResolvedUpdateBundlePathAsync` and `UpdateHelper.getLatestUpdateBundlePathForRuntimeVersionAsync` — both unused after this change.

### Backwards compatibility

Clients holding a cached pre-deploy manifest will hit asset URLs without `releaseId` and get a `400`. The Expo client treats a failed asset fetch as a failed update — falls back to the embedded bundle and re-polls the manifest, which returns the new URL shape. One missed update, auto-recovers next poll. Acceptable for a correctness fix of this kind.

### Out of scope

- Signed/capability asset URLs. Today any URL the manifest emits is fetchable by anyone holding it (releaseIds are UUIDs, not enumerable, but they leak through the manifest itself). This PR fixes correctness, not confidentiality — if the threat model later requires per-user gating, that's a signed-URL + TTL change.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx jest` — 51/51 tests pass (manifest mocks updated, new `assets.test.ts` covers missing releaseId → 400, unknown release → 404, runtimeVersion mismatch → 400, happy path serves from `release.path`)
- [x] `npx eslint apiUtils pages` clean
- [ ] Manual e2e once merged: publish one beta + one prod release on the same runtime version, confirm a beta user's manifest asset URLs carry a different `releaseId` from a default user's, and fetching each URL returns the corresponding bundle's bytes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)